### PR TITLE
feat: add /analyze-session skill and improvement tracker

### DIFF
--- a/.claude/analysis/improvement-tracker.md
+++ b/.claude/analysis/improvement-tracker.md
@@ -1,0 +1,182 @@
+# Figmagent Improvement Tracker
+
+Last updated: 2026-03-14
+Sessions analyzed: 2
+
+## Active Issues
+
+### [TOOL-001] bind_variable needs batch version
+- **Status**: implemented
+- **Priority**: P0
+- **Category**: missing-batch-tool
+- **First seen**: Session 2 (2026-03-06)
+- **Sessions affected**: 2
+- **Estimated savings**: ~120 calls/session
+- **Description**: 132 individual `bind_variable` calls dominated session 2. Longest uninterrupted run was 28 consecutive calls. Agent groups conceptually but has no batch tool to execute.
+- **Current status**: Implemented via `apply` tool with `variables` field — accepts map of field→variableId for design token bindings on one or many nodes.
+- **Auto-fixable**: no (tool-level change)
+
+### [TOOL-002] set_text_style needs batch version
+- **Status**: implemented
+- **Priority**: P0
+- **Category**: missing-batch-tool
+- **First seen**: Session 2 (2026-03-06)
+- **Sessions affected**: 2
+- **Estimated savings**: ~45 calls/session
+- **Description**: 55 individual `set_text_style` calls. Agent applies same style to 9+ nodes at a time.
+- **Current status**: Implemented via `apply` tool with `textStyleId` field — deduplicates font loading across multiple nodes automatically.
+- **Auto-fixable**: no (tool-level change)
+
+### [BUG-001] set_text_style sync/async bug
+- **Status**: implemented
+- **Priority**: P0
+- **Category**: plugin-bug
+- **First seen**: Session 2 (2026-03-06)
+- **Sessions affected**: 2
+- **Estimated savings**: 12 calls + ~5 minutes per occurrence
+- **Description**: `set_text_style` handler used sync `textStyleId` setter, fails with `documentAccess: dynamic-page`. Needs `setTextStyleIdAsync`. 9 failed calls + 3 code fix attempts in session 2.
+- **Fix pattern**: sync-to-async
+- **Current status**: Fixed — async API used throughout plugin code.
+- **Auto-fixable**: yes (sync-to-async pattern)
+
+### [TOOL-003] get_local_components output too large
+- **Status**: implemented
+- **Priority**: P1
+- **Category**: missing-tool
+- **First seen**: Session 2 (2026-03-06)
+- **Sessions affected**: 2
+- **Estimated savings**: avoids context overflow
+- **Description**: Response was 107,546 characters, exceeding token limit. Agent tried Bash/Python parsing workarounds.
+- **Current status**: Implemented via output budget system — 30K char default, `maxOutputChars` parameter to adjust. `preferredValues` arrays stripped from instance `componentProperties`.
+
+### [TOOL-004] get_node_info default depth too shallow
+- **Status**: implemented
+- **Priority**: P1
+- **Category**: agent-behavior
+- **First seen**: Session 1 (2026-03-05)
+- **Sessions affected**: 1, 2
+- **Estimated savings**: ~15-29 redundant re-inspections per session
+- **Description**: Agent inspects at depth=1 then needs depth=2 later. 22 nodes queried more than once in session 2.
+- **Current status**: CLAUDE.md now instructs "Always start with detail=structure and depth=2" and the `get` tool enforces this guidance.
+
+### [TOOL-005] ToolSearch overhead
+- **Status**: identified
+- **Priority**: P1
+- **Category**: infrastructure
+- **First seen**: Session 1 (2026-03-05)
+- **Sessions affected**: 1, 2
+- **Estimated savings**: ~28-33 calls/session
+- **Description**: Agent rediscovers same tools repeatedly. 33 calls in session 1 (10.7%), 28 in session 2 (7.2%). 4 consecutive failed searches when tools hadn't been loaded after MCP restart.
+- **Proposed fix**: Pre-load tool schemas at session start; add complete tool reference to skill file; make ToolSearch return explicit "not found in server" vs "0 results".
+
+### [AGENT-001] Fail fast on repeated identical errors
+- **Status**: implemented
+- **Priority**: P1
+- **Category**: agent-behavior
+- **First seen**: Session 2 (2026-03-06)
+- **Sessions affected**: 2
+- **Description**: Agent fired 7 more identical `set_text_style` calls after first 2 failures. Should stop after 2 and tell user.
+- **Current status**: CLAUDE.md now includes "After 2 consecutive identical errors on the same tool, stop retrying and diagnose the root cause".
+
+### [AGENT-002] After 2 timeouts assume disconnection
+- **Status**: implemented
+- **Priority**: P1
+- **Category**: agent-behavior
+- **First seen**: Session 2 (2026-03-06)
+- **Sessions affected**: 2
+- **Description**: 5 consecutive timeout calls before escalating. 30s per call = ~2.5 minutes wasted.
+- **Current status**: CLAUDE.md now includes "After 2 timeouts in a row, assume the WebSocket connection is lost — call join_channel to re-establish before retrying".
+
+### [TOOL-006] Type coercion for tool parameters
+- **Status**: identified
+- **Priority**: P1
+- **Category**: type-coercion
+- **First seen**: Session 1 (2026-03-05)
+- **Sessions affected**: 1
+- **Estimated savings**: eliminates cascading error batches (8 errors from 2 root causes in session 1)
+- **Description**: Agent passes `"4"` instead of `4` for radius, `"0.85"` instead of `0.85` for colors. When one call in parallel batch errors, all parallel calls cancelled.
+- **Fix pattern**: type-coercion
+- **Auto-fixable**: yes (add `toNumber()` coercion or Zod `.transform(Number)`)
+
+### [INFRA-001] Channel reconnection tax
+- **Status**: improved
+- **Priority**: P2
+- **Category**: infrastructure
+- **First seen**: Session 1 (2026-03-05)
+- **Sessions affected**: 1, 2
+- **Description**: 8 reconnections in session 1 consuming ~40+ overhead calls. Each MCP restart forces new channel + ToolSearch + context re-establishment.
+- **Current status**: Auto-reconnect improved; plugin now uses channel named after file and auto-rejoins. Still 4 MCP restarts needed in session 2 for picking up new tools/fixing bugs.
+
+### [AGENT-003] Verify instance vs component before modifying
+- **Status**: implemented
+- **Priority**: P2
+- **Category**: agent-behavior
+- **First seen**: Session 1 (2026-03-05)
+- **Sessions affected**: 1
+- **Description**: Agent modified INSTANCE instead of COMPONENT_SET. Wasted planning work on wrong node.
+- **Current status**: CLAUDE.md key patterns now document instance vs component handling. `get` returns `componentRef` in `defs.components` for instances.
+
+### [TOOL-007] Composite create tool
+- **Status**: implemented
+- **Priority**: P0
+- **Category**: missing-tool
+- **First seen**: Session 1 (2026-03-05)
+- **Sessions affected**: 1
+- **Estimated savings**: ~104 calls (create_frame + set_layout_sizing were #1 and #2 most-called tools)
+- **Current status**: `create` tool handles single nodes, nested trees, components, and instances. FILL sizing applied in second pass. Built 41 nodes in 1 call in session 2.
+- **Verified in**: Session 2
+
+### [TOOL-008] reorder_children tool
+- **Status**: implemented
+- **Priority**: P1
+- **Category**: missing-tool
+- **First seen**: Session 1 (2026-03-05)
+- **Sessions affected**: 1
+- **Description**: Agent had to delete and recreate nodes just to change ordering.
+- **Current status**: `reorderChildren` command exists in modify.js.
+- **Verified in**: Session 2 (no delete-recreate cycles observed for ordering)
+
+### [TOOL-009] read_my_design response too large
+- **Status**: implemented
+- **Priority**: P1
+- **Category**: missing-tool
+- **First seen**: Session 1 (2026-03-05)
+- **Sessions affected**: 1
+- **Description**: `read_my_design` returned 309,417 characters. Forced complex chunked-reading with bash/python scripts.
+- **Current status**: `get` tool with detail levels (structure/layout/full) and depth parameter. Output budget system caps at 30K chars by default.
+
+## Resolved Issues
+
+### [TOOL-007] Composite create tool
+- **Resolved in**: Session 2
+- **Original savings estimate**: ~104 calls
+- **Actual improvement**: `create_frame_tree` built 41 nodes in 1 call
+
+### [TOOL-008] reorder_children tool
+- **Resolved in**: Session 2
+- **Verification**: No delete-recreate cycles observed for ordering in session 2
+
+### [AGENT-001] Fail fast on repeated identical errors
+- **Resolved in**: Post-session 2 (CLAUDE.md update)
+
+### [AGENT-002] After 2 timeouts assume disconnection
+- **Resolved in**: Post-session 2 (CLAUDE.md update)
+
+### [AGENT-003] Verify instance vs component before modifying
+- **Resolved in**: Post-session 2 (CLAUDE.md update)
+
+## Metrics Over Time
+
+| Session | Date | Tool Calls | Errors | Waste % | ToolSearch | New Issues | Resolved |
+|---------|------|------------|--------|---------|------------|------------|----------|
+| 1 | 2026-03-05 | 308 | 16 | 25-33% | 33 (10.7%) | 15 | 0 |
+| 2 | 2026-03-06 | 389 | 14 | ~17.7% | 28 (7.2%) | 4 | 3 |
+
+## Issue Categories
+
+- `missing-batch-tool` — tool exists but lacks batch variant
+- `plugin-bug` — bug in Figma plugin code
+- `type-coercion` — MCP server rejects valid-but-wrong-type input
+- `missing-tool` — capability gap requiring new tool
+- `agent-behavior` — prompt/skill improvement needed
+- `infrastructure` — WebSocket, reconnection, schema freshness

--- a/.claude/skills/analyze-session/SKILL.md
+++ b/.claude/skills/analyze-session/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: analyze-session
+description: "Analyze a Figma MCP test session transcript. Reads raw session data (JSON or HTML) and produces a structured analysis document with metrics, efficiency issues, error patterns, and prioritized improvements. Updates the cross-session improvement tracker. Use after completing a Figma session or when reviewing past sessions. Accepts an optional file path argument; if omitted, analyzes the most recent transcript."
+---
+
+# Analyze Session Transcript
+
+Analyze a Figma MCP test session transcript and produce a structured efficiency/error audit. After large Figma sessions (50+ tool calls), run this skill to capture learnings and track improvement over time.
+
+---
+
+## Phase 1: Locate and Ingest Transcript
+
+1. If a file path argument was provided, use that. Otherwise, scan for the most recent transcript:
+   - Check `.claude/transcripts/` and `.claude/sessions-json/` for files sorted by modification time
+   - Accept both JSON and HTML formats
+
+2. **For JSON transcripts** (preferred format — see schema below):
+   - Read the file. If >500 lines, read in 500-line chunks.
+   - Extract events from the `events` array.
+
+3. **For HTML transcripts** (fallback):
+   - Read page by page (each HTML file is one page).
+   - Extract tool call blocks using pattern matching: look for tool names, parameters, results, and error messages.
+
+4. **Three-pass approach** (critical for large transcripts — 800+ events):
+   - **Pass 1 (Extract)**: Read in chunks. For each event, record ONLY: timestamp, tool name, error status, target node ID, duration. Output a compact one-line-per-event summary. This reduces 300KB → ~15KB.
+   - **Pass 2 (Analyze)**: Over the compact summary, compute all metrics and identify patterns.
+   - **Pass 3 (Detail)**: For each flagged issue/error pattern, go back to the original transcript to extract specific context (error messages, parameter values, cascading effects).
+
+### Recommended JSON Transcript Schema
+
+For optimal automated analysis, transcripts should follow this structure:
+
+```json
+{
+  "sessionId": "uuid",
+  "startTime": "ISO-8601",
+  "endTime": "ISO-8601",
+  "figmaFile": "file-name",
+  "task": "Brief description of the session's goal",
+  "events": [
+    {
+      "timestamp": "ISO-8601",
+      "type": "tool_call",
+      "toolName": "create",
+      "params": { "type": "FRAME", "name": "Header", "parentId": "123:456" },
+      "durationMs": 1234
+    },
+    {
+      "timestamp": "ISO-8601",
+      "type": "tool_result",
+      "toolName": "create",
+      "result": { "success": true, "nodeId": "789:012" },
+      "durationMs": 0
+    },
+    {
+      "timestamp": "ISO-8601",
+      "type": "error",
+      "toolName": "apply",
+      "error": "Cannot call with documentAccess: dynamic-page",
+      "params": { "nodeId": "789:012" }
+    }
+  ]
+}
+```
+
+Fields: `type` is one of `tool_call`, `tool_result`, `user`, `assistant`, `error`. `toolName` uses the MCP tool name (e.g., `create`, `apply`, `get`, `find`, `join_channel`). `durationMs` is wall-clock time from call to response.
+
+---
+
+## Phase 2: Compute Metrics
+
+Calculate these standard metrics from the extracted events:
+
+### Session Overview
+- **Duration**: end time - start time
+- **Total events**: count of all events
+- **Total tool calls**: count of `tool_call` events
+- **Total errors**: count of `error` events or tool results with error status
+- **Reconnections**: count of `join_channel` calls that were re-joins (not initial join)
+- **Context overflows**: detect by looking for continuation summaries or session restart markers
+- **Phases completed**: identify distinct work phases from the transcript
+
+### Tool Call Distribution Table
+For each unique tool name:
+- Count total invocations
+- Note patterns:
+  - "no batch version" if >20 sequential calls to same tool
+  - "N redundant re-inspections" if same node ID appears in multiple `get` calls
+  - "N failed" if error count > 0
+
+### Error Extraction
+- Group errors by error message pattern (normalize variable parts like node IDs)
+- Count cascading errors: when one error in a parallel batch causes all parallel calls to fail, count the root error separately from cascaded ones
+- Identify root cause vs symptom errors
+
+### Efficiency Signals — Detect These Patterns
+
+1. **Sequential same-tool runs**: 5+ consecutive calls to the same tool → batch candidate. Record: tool name, run length, what a batch version would look like.
+
+2. **Inspect-after-create**: `create` or `clone_node` immediately followed by `get` on the created node → indicates create response should be richer. Count occurrences.
+
+3. **Delete-recreate cycles**: `delete_node`/`delete_multiple_nodes` followed by `create` for the same purpose → indicates missing modify capability or wrong initial approach.
+
+4. **ToolSearch overhead**: total ToolSearch calls, percentage of all calls, failed searches (found wrong tools or 0 results).
+
+5. **Redundant re-inspections**: same node ID appearing in multiple `get` calls → count unique nodes vs total `get` calls.
+
+6. **Timeout cascades**: 3+ consecutive timeouts → connection loss not detected fast enough.
+
+7. **Error retry storms**: same error repeated 3+ times → fail-fast rule violated.
+
+---
+
+## Phase 3: Cross-Session Comparison
+
+1. Read the improvement tracker at `.claude/analysis/improvement-tracker.md`
+2. Read the most recent previous analysis from `.claude/analysis/` (by filename number)
+3. Compute deltas:
+   - Waste percentage change
+   - Error rate change
+   - ToolSearch overhead change
+   - New tools used that didn't exist in previous session
+   - Recurring issues vs new issues
+4. Check which previously-identified issues were addressed:
+   - Tool exists now that was flagged as missing? → Mark as `implemented`
+   - Error pattern from previous session not observed? → Mark as `verified`
+   - Same issue still present? → Increment sessions affected count
+
+---
+
+## Phase 4: Generate Analysis Document
+
+Write the analysis to `.claude/analysis/figma-mcp-session<N>-analysis.md` where N is auto-incremented based on existing files in the directory.
+
+Use this exact template structure (matching the format of existing session 1 and session 2 analyses):
+
+```markdown
+# Figma MCP Session <N> Analysis
+
+## Session Overview
+
+- **Transcript**: `<filename>`
+- **Duration**: <duration>
+- **Total tool calls**: <count>
+- **Total errors**: <count>
+- **Reconnections**: <count>
+- **Context restarts**: <count>
+- **Task**: <brief description>
+
+## Metrics
+
+| Metric | Previous Session | This Session | Change |
+|---|---|---|---|
+| Total Figma tool calls | ... | ... | ... |
+| Meta/overhead calls | ... | ... | ... |
+| ToolSearch calls | ... | ... | ... |
+| Estimated waste % | ... | ... | ... |
+
+## Tool Call Distribution
+
+| Tool | Calls | Notes |
+|---|---|---|
+| ... | ... | ... |
+
+## Efficiency Issues
+
+### 1. <Issue title> (saves ~N calls)
+
+<Description of the pattern observed. Include specific numbers — how many consecutive calls, which nodes, what the agent was trying to do.>
+
+**Pattern observed:** <concrete example from the transcript>
+
+**Root cause:** <why this happened — missing tool, wrong default, agent behavior>
+
+**Proposed fix:** <specific actionable recommendation>
+
+**Estimated savings:** ~N calls → ~M calls.
+
+### 2. ...
+
+## Error Analysis
+
+### 1. <Error category> (<N> failures, ~<M> minutes lost)
+
+<Description. Include the exact error message. Trace cascading effects.>
+
+**Agent recovery:** <how the agent responded — did it fail fast? retry too many times?>
+
+**Fix needed:** <specific code or behavior change>
+
+### 2. ...
+
+## What Worked Well
+
+1. **<Tool/pattern>.** <Why it was effective, with specific numbers.>
+2. ...
+
+## Priority Improvements
+
+### Tool Changes (ranked by call savings)
+
+1. **<tool name>** — <what it should do>. Saves ~N calls per session.
+2. ...
+
+### Agent Skill Updates
+
+1. **<behavior change>** — <description>.
+2. ...
+```
+
+---
+
+## Phase 5: Update Improvement Tracker
+
+Update `.claude/analysis/improvement-tracker.md`:
+
+1. **Add new issues**: For each efficiency issue or error pattern identified in this analysis that doesn't already exist in the tracker:
+   - Assign an ID: `[CATEGORY-NNN]` where CATEGORY is TOOL, BUG, AGENT, or INFRA
+   - Auto-increment NNN within the category
+   - Set status to `identified`
+   - Set priority based on estimated call savings: P0 (>50 calls), P1 (10-50 calls), P2 (<10 calls)
+   - Classify as auto-fixable if it matches a known fix pattern (see Phase 6)
+
+2. **Update existing issues**: For each tracker entry:
+   - If the issue was not observed in this session and the fix is confirmed working → advance to `verified`, move to Resolved Issues
+   - If the issue recurred → add this session number to "Sessions affected"
+   - If a tool was implemented that addresses the issue → advance to `implemented`
+
+3. **Deduplication**: Match new findings against existing entries by:
+   - Category match
+   - Tool name match (if issue references a specific tool)
+   - Key phrase match (substring: "batch", "async", "timeout", "coercion", etc.)
+   - If match found → increment occurrence count, don't create duplicate
+
+4. **Update Metrics Over Time table**: Add a row for this session.
+
+5. **Update "Last updated" date and "Sessions analyzed" count**.
+
+---
+
+## Phase 6: Generate Fix Plans (if applicable)
+
+For issues marked `auto-fixable: yes` in the tracker, generate implementation plans. Plans go to `.claude/plans/<date>-<issue-id>.md`.
+
+### Safe Fix Patterns (allowlist)
+
+Only generate plans for these well-understood patterns:
+
+#### `sync-to-async`
+- **Trigger**: Error message contains "Cannot call with documentAccess: dynamic-page" or "Use node.setXxxAsync instead"
+- **Fix**: Find the sync call in plugin source, replace with async equivalent
+- **Plan content**: Exact file path, line number, old code → new code
+- **Example**: `node.textStyleId = id` → `await node.setTextStyleIdAsync(id)`
+
+#### `type-coercion`
+- **Trigger**: Error message contains "expected number, received string" or similar type mismatch
+- **Fix**: Add `toNumber()` coercion in the plugin handler (helper already exists in `src/figma_plugin/src/helpers.js`) or add `.or(z.string().transform(Number))` to the Zod schema in the MCP tool handler
+- **Plan content**: File path, parameter name, Zod schema change or `toNumber()` wrapping
+
+#### `missing-batch-tool`
+- **Trigger**: Single-item tool called 20+ times consecutively
+- **Fix**: Create batch variant following existing patterns (`set_multiple_text_contents`, `delete_multiple_nodes`)
+- **Plan content**: Tool specification (name, parameters, behavior) for use with `/add-mcp-tool` skill. Include the proposed JSON input format based on observed usage patterns.
+
+### Plan Format
+
+```markdown
+# Fix: [ISSUE-ID] <title>
+
+**Pattern**: <sync-to-async | type-coercion | missing-batch-tool>
+**Priority**: <P0 | P1 | P2>
+**Estimated savings**: <N calls/session>
+
+## Changes
+
+### File: `<path>`
+- Line N: `<old code>` → `<new code>`
+
+## Verification
+- [ ] Run `bun run lint`
+- [ ] Run `bun run test`
+- [ ] Run `bun run build:plugin`
+- [ ] Test in a Figma session
+```
+
+**Important**: The skill NEVER applies code changes directly. It only generates plan files and marks issues as `planned` in the tracker. The user reviews and triggers implementation.
+
+---
+
+## Notes
+
+- If the transcript is too large to fit in context even with the 3-pass approach, focus on the tool call distribution and error extraction (Phases 2a-2b) and skip detailed efficiency pattern analysis for the middle sections.
+- Always validate numbers: total tool calls should equal sum of distribution table. Error count should match error analysis section.
+- When comparing sessions, normalize for scope differences (session 2 had 26% more tool calls because the task was larger, not because it was less efficient).
+- The analysis document is committed to git — it serves as a permanent record of the session and its learnings.

--- a/.claude/skills/figma-guidelines/SKILL.md
+++ b/.claude/skills/figma-guidelines/SKILL.md
@@ -307,3 +307,5 @@ Read these for detailed coverage on specific topics:
 | `references/variables-and-styles.md` | Setting up design tokens, creating variable collections/modes, choosing variables vs styles |
 | `references/gotchas-and-edge-cases.md` | Debugging errors, understanding why something failed, edge cases with fills/text/instances |
 | `references/collaboration-and-organization.md` | Adding comments/annotations, organizing files with sections, Dev Mode preparation, branching |
+
+**Post-session**: After completing a large Figma session (50+ tool calls), run `/analyze-session` to capture efficiency metrics, error patterns, and improvement recommendations.

--- a/.claude/skills/figma-sub-agents/SKILL.md
+++ b/.claude/skills/figma-sub-agents/SKILL.md
@@ -358,3 +358,7 @@ TIME    ORCHESTRATOR              STYLER-A              STYLER-B
 - Parallel (3 agents): ~19 minutes (~1.9x speedup)
 
 The speedup scales with workload size. Design system builds with 50+ components see larger gains because build and style phases dominate.
+
+---
+
+**Post-session**: After completing a large Figma session (50+ tool calls), run `/analyze-session` to capture efficiency metrics, error patterns, and improvement recommendations.


### PR DESCRIPTION
Automates post-session analysis of Figma MCP test transcripts:
- /analyze-session skill reads JSON/HTML transcripts, computes metrics,
  detects efficiency patterns, and produces structured analysis docs
- Improvement tracker backfilled from sessions 1 & 2 with 15 tracked
  issues, status lifecycle, and cross-session metrics table
- Cross-skill reminders in figma-guidelines and figma-sub-agents

https://claude.ai/code/session_01AV29FTBathtoB8MxxBQPqW