### PR TITLE
fix: add deprecation notices to scan tools in favor of find

### DIFF
--- a/src/figmagent_mcp/tools/scan.ts
+++ b/src/figmagent_mcp/tools/scan.ts
@@ -7,7 +7,7 @@ import { guardOutput, extractJsonSummary } from "../utils.js";
 // Node Type Scanning Tool
 server.tool(
   "scan_nodes_by_types",
-  "Scan for child nodes with specific types. Prefer find() for most searches — it supports more criteria and groups results by ancestor.",
+  "DEPRECATED — use find() instead, which supports type, name, componentId, and other criteria with output budget control. This tool can return very large responses that overflow context. find() groups results by ancestor and enforces a 30K char budget.",
   {
     nodeId: z.string().describe("ID of the node to scan"),
     types: z

--- a/src/figmagent_mcp/tools/text.ts
+++ b/src/figmagent_mcp/tools/text.ts
@@ -41,7 +41,7 @@ server.tool(
 // Text Node Scanning Tool
 server.tool(
   "scan_text_nodes",
-  "Scan all text nodes in the selected Figma node",
+  "DEPRECATED — use find(text: \"regex\") instead for targeted text search with output budget control. This tool returns all text nodes which can overflow context on large designs.",
   {
     nodeId: z.string().describe("ID of the node to scan"),
   },


### PR DESCRIPTION
## Summary

- Marks `scan_nodes_by_types` and `scan_text_nodes` as DEPRECATED in their tool descriptions
- Points agents to `find()` which supports the same criteria with output budget control
- No logic changes — tools still work for backward compat

Closes #11

## Test plan

- [x] `bun run lint` passes
- [ ] Verify agents see the DEPRECATED notice and prefer `find()` in future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)