### PR TITLE
fix: add font-change guidance to delete_node description

### DIFF
--- a/src/figmagent_mcp/tools/modify.ts
+++ b/src/figmagent_mcp/tools/modify.ts
@@ -144,7 +144,7 @@ server.tool(
 // Delete Node Tool
 server.tool(
   "delete_node",
-  "Delete a node from Figma",
+  "Delete a node from Figma. Do NOT delete TEXT nodes to change font properties — use apply with fontFamily/fontWeight/fontSize instead.",
   {
     nodeId: z.string().describe("The ID of the node to delete"),
   },


### PR DESCRIPTION
## Summary

- Adds warning to `delete_node` tool description: "Do NOT delete TEXT nodes to change font properties — use apply with fontFamily/fontWeight/fontSize instead."
- The `apply` tool description already includes this guidance with examples (line 128)

Closes #9

## Test plan

- [x] `bun run lint` passes
- [ ] Verify agents prefer `apply` for font changes instead of delete-recreate cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)