### PR TITLE
fix: load fonts before reparenting in import_library_component

### DIFF
--- a/src/figma_plugin/src/commands/components.js
+++ b/src/figma_plugin/src/commands/components.js
@@ -151,6 +151,42 @@ export async function importLibraryComponent(params) {
 
   const instance = imported.createInstance();
 
+  // Load fonts for all TEXT nodes in the imported component before reparenting.
+  // Without this, appending to a parentNodeId fails on components containing text.
+  if (parentNodeId) {
+    const fontsToLoad = new Set();
+    const collectFonts = (node) => {
+      if (node.type === "TEXT") {
+        const len = node.characters ? node.characters.length : 0;
+        if (len > 0) {
+          for (let i = 0; i < len; i++) {
+            const font = node.getRangeFontName(i, i + 1);
+            if (font && typeof font !== "symbol") {
+              fontsToLoad.add(font.family + "::" + font.style);
+            }
+          }
+        } else if (node.fontName && typeof node.fontName !== "symbol") {
+          fontsToLoad.add(node.fontName.family + "::" + node.fontName.style);
+        }
+      }
+      if (node.children) {
+        for (const child of node.children) {
+          collectFonts(child);
+        }
+      }
+    };
+    collectFonts(instance);
+
+    if (fontsToLoad.size > 0) {
+      const fontPromises = [];
+      for (const key of fontsToLoad) {
+        const parts = key.split("::");
+        fontPromises.push(figma.loadFontAsync({ family: parts[0], style: parts[1] }));
+      }
+      await Promise.all(fontPromises);
+    }
+  }
+
   if (position) {
     instance.x = position.x;
     instance.y = position.y;


### PR DESCRIPTION
When import_library_component is called with parentNodeId, the instance is created then appended to the parent frame. If the imported component contains TEXT nodes, this fails because fonts are not loaded before the reparent operation.

Walk the instance tree to collect all unique fonts from text nodes and load them via figma.loadFontAsync() before the appendChild call. Uses getRangeFontName() to handle mixed-font text nodes correctly.

This eliminates the workaround of clone + manual reparent that cost ~36 extra tool calls per affected session.

Closes #20

https://claude.ai/code/session_01X5z9K2Yt6drKqEWC7NCURV

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- Bullet list of what changed -->

## Checklist

- [ ] `bun run lint` passes
- [ ] `bun run test` passes
- [ ] `bun run build:plugin` succeeds (if plugin source changed)
- [ ] Tested in Figma (if plugin behavior changed)
- [ ] Updated CLAUDE.md (if tool behavior or patterns changed)
