### PR TITLE
docs: add ToolSearch caching guidance to reduce overhead in short ses…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,3 +146,4 @@ Uncomment the `hostname: "0.0.0.0"` line in `src/socket.ts` to allow connections
 - The plugin and relay must both be running before any tool calls succeed
 - After 2 consecutive identical errors on the same tool, stop retrying and diagnose the root cause (wrong node ID, lost connection, or type mismatch)
 - After 2 timeouts in a row, assume the WebSocket connection is lost — call `join_channel` to re-establish before retrying
+- Tool schemas are stable within a session. Cache tool schemas after the first ToolSearch call — do not re-fetch the same tool's schema on every use. After reconnection, a single ToolSearch for the tools you plan to use is sufficient. Batch ToolSearch calls when possible rather than fetching one tool at a time.


### PR DESCRIPTION
…sions

Closes #15

Tool schemas are stable within a session, so agents should cache them after the first fetch rather than re-fetching before every tool use. This note in Agent Notes helps agents avoid the 4-44% overhead from repeated ToolSearch calls observed in session analysis.

The MCP server already exposes comprehensive tool descriptions and parameter schemas via the MCP SDK's tools/list endpoint, so no server changes are needed — the fix is agent-side behavior guidance.

https://claude.ai/code/session_01X5z9K2Yt6drKqEWC7NCURV

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- Bullet list of what changed -->

## Checklist

- [ ] `bun run lint` passes
- [ ] `bun run test` passes
- [ ] `bun run build:plugin` succeeds (if plugin source changed)
- [ ] Tested in Figma (if plugin behavior changed)
- [ ] Updated CLAUDE.md (if tool behavior or patterns changed)
