### PR TITLE
feat: add prepare_figma_variables MCP tool for DTCG JSON conversion

### DIFF
--- a/src/figmagent_mcp/tools/tokens.ts
+++ b/src/figmagent_mcp/tools/tokens.ts
@@ -233,10 +233,13 @@ Multiple operations in one call:
 
 // Prepare Figma Variables Tool — DTCG JSON to create_variables payloads (MCP-server-side, no Figma connection needed)
 
-function hexToRgba(hex: string): { r: number; g: number; b: number; a: number } {
+export function hexToRgba(hex: string): { r: number; g: number; b: number; a: number } {
   let h = hex.replace(/^#/, "");
   if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
   if (h.length === 4) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2] + h[3] + h[3];
+  if (h.length !== 6 && h.length !== 8) {
+    throw new Error(`Invalid hex color "${hex}" — expected #RGB, #RGBA, #RRGGBB, or #RRGGBBAA`);
+  }
   const r = Number.parseInt(h.slice(0, 2), 16) / 255;
   const g = Number.parseInt(h.slice(2, 4), 16) / 255;
   const b = Number.parseInt(h.slice(4, 6), 16) / 255;
@@ -253,7 +256,11 @@ interface ParsedVariable {
   scopes: string[];
 }
 
-function dtcgTypeToFigma(dtcgType: string): FigmaVariableType {
+type ConvertResult =
+  | { ok: true; value: unknown; warning?: string }
+  | { ok: false; error: string };
+
+export function dtcgTypeToFigma(dtcgType: string): FigmaVariableType {
   switch (dtcgType) {
     case "color":
       return "COLOR";
@@ -273,38 +280,54 @@ function dtcgTypeToFigma(dtcgType: string): FigmaVariableType {
   }
 }
 
-function convertValue(dtcgType: string, value: unknown): unknown {
-  if (value === null || value === undefined) return value;
+export function convertValue(dtcgType: string, value: unknown): ConvertResult {
+  if (value === null || value === undefined) return { ok: true, value };
 
   switch (dtcgType) {
     case "color": {
-      if (typeof value === "string" && value.startsWith("#")) {
-        return hexToRgba(value);
+      if (typeof value === "string" && value.startsWith("{") && value.endsWith("}")) {
+        return { ok: false, error: `Alias "${value}" cannot be resolved — provide resolved values or use create_variables with alias references directly` };
       }
-      if (typeof value === "object") return value;
-      return value;
+      if (typeof value === "string" && value.startsWith("#")) {
+        return { ok: true, value: hexToRgba(value) };
+      }
+      if (typeof value === "object") return { ok: true, value };
+      return { ok: false, error: `Unsupported color value: ${String(value)}` };
     }
     case "number":
     case "dimension":
     case "duration":
     case "fontWeight": {
-      if (typeof value === "number") return value;
+      if (typeof value === "number") return { ok: true, value };
       if (typeof value === "string") {
+        if (value.toLowerCase() === "auto") {
+          return { ok: false, error: `"auto" cannot be converted to a FLOAT variable` };
+        }
+        const remMatch = value.match(/^([\d.]+)rem$/i);
+        if (remMatch) {
+          const px = Number.parseFloat(remMatch[1]) * 16;
+          return { ok: true, value: px, warning: `"${value}" converted assuming 1rem=16px (→${px}px); verify if your base font size differs` };
+        }
         const num = Number.parseFloat(value);
-        return Number.isNaN(num) ? 0 : num;
+        if (Number.isNaN(num)) return { ok: false, error: `Cannot parse "${value}" as a number` };
+        return { ok: true, value: num };
       }
-      return 0;
+      return { ok: false, error: `Unsupported numeric value: ${String(value)}` };
     }
     case "boolean": {
-      if (typeof value === "boolean") return value;
-      return value === "true";
+      if (typeof value === "boolean") return { ok: true, value };
+      return { ok: true, value: value === "true" };
     }
-    default:
-      return typeof value === "string" ? value : String(value);
+    default: {
+      if (typeof value === "object" && value !== null) {
+        return { ok: false, error: `Composite $type "${dtcgType}" has an object value — cannot be represented as a single Figma variable` };
+      }
+      return { ok: true, value: typeof value === "string" ? value : String(value) };
+    }
   }
 }
 
-function inferScopes(path: string, figmaType: FigmaVariableType): string[] {
+export function inferScopes(path: string, figmaType: FigmaVariableType): string[] {
   const lower = path.toLowerCase();
 
   if (figmaType === "COLOR") {
@@ -325,7 +348,7 @@ function inferScopes(path: string, figmaType: FigmaVariableType): string[] {
     if (lower.includes("font-weight") || lower.includes("fontweight")) return ["FONT_WEIGHT"];
     if (lower.includes("line-height") || lower.includes("lineheight")) return ["LINE_HEIGHT"];
     if (lower.includes("letter-spacing") || lower.includes("letterspacing")) return ["LETTER_SPACING"];
-    if (lower.includes("stroke") || lower.includes("border-width")) return ["STROKE_FLOAT"];
+    if (lower.includes("stroke") || lower.includes("border-width") || lower.includes("border/width")) return ["STROKE_FLOAT"];
     if (lower.includes("size") || lower.includes("width") || lower.includes("height")) return ["WIDTH_HEIGHT"];
     return ["ALL_SCOPES"];
   }
@@ -339,29 +362,35 @@ function inferScopes(path: string, figmaType: FigmaVariableType): string[] {
   return ["ALL_SCOPES"];
 }
 
-function walkDtcgTree(
+export function walkDtcgTree(
   obj: Record<string, unknown>,
   path: string[],
   prefix: string,
   inheritedType: string | undefined,
   results: ParsedVariable[],
+  errors: string[],
+  warnings: string[],
 ): void {
   // Check if this is a leaf token (has $value)
   if (obj["$value"] !== undefined) {
     const dtcgType = (typeof obj["$type"] === "string" ? obj["$type"] : inheritedType) || "string";
     const figmaType = dtcgTypeToFigma(dtcgType);
     let name = path.join("/");
-    if (prefix && name.startsWith(prefix)) {
+    if (prefix && (name === prefix || name.startsWith(`${prefix}/`))) {
       name = name.slice(prefix.length);
     }
     // Remove leading slashes after prefix strip
     name = name.replace(/^\/+/, "");
     if (!name) return;
 
-    const converted = convertValue(dtcgType, obj["$value"]);
+    const result = convertValue(dtcgType, obj["$value"]);
+    if (!result.ok) {
+      errors.push(`${name}: ${result.error}`);
+      return;
+    }
+    if (result.warning) warnings.push(`${name}: ${result.warning}`);
     const scopes = inferScopes(name, figmaType);
-
-    results.push({ name, type: figmaType, value: converted, scopes });
+    results.push({ name, type: figmaType, value: result.value, scopes });
     return;
   }
 
@@ -371,25 +400,26 @@ function walkDtcgTree(
     if (key.startsWith("$")) continue; // skip DTCG metadata keys
     const child = obj[key];
     if (child !== null && typeof child === "object" && !Array.isArray(child)) {
-      walkDtcgTree(child as Record<string, unknown>, [...path, key], prefix, groupType, results);
+      walkDtcgTree(child as Record<string, unknown>, [...path, key], prefix, groupType, results, errors, warnings);
     }
   }
 }
 
 server.tool(
   "prepare_figma_variables",
-  `Convert DTCG-format design tokens to create_variables-ready payloads. Handles hex→RGBA conversion, $value/$type parsing, alias resolution, scope inference, and batch chunking.
+  `Convert DTCG-format design tokens to create_variables-ready payloads. Handles hex→RGBA conversion, $value/$type parsing, scope inference, and batch chunking.
 
 Runs entirely on the MCP server — no Figma connection needed. Feed the output batches directly to create_variables.
 
 Input a DTCG token tree:
   { tokens: { "color": { "$type": "color", "primary": { "500": { "$value": "#3366FF" } } }, "spacing": { "$type": "dimension", "sm": { "$value": "8px" } } } }
 
-Returns an array of create_variables-ready payloads, each with at most batchSize variables:
-  [{ collection: "Tokens", modes: ["Default"], variables: [{ name: "color/primary/500", type: "COLOR", scopes: ["ALL_FILLS"], values: { "Default": { r: 0.2, g: 0.4, b: 1, a: 1 } } }, ...] }]
+Returns batches plus errors and warnings:
+  { totalVariables: 2, totalBatches: 1, errors: [], warnings: [], batches: [{ collection: "Tokens", modes: ["Default"], variables: [...] }] }
 
 Supported DTCG $type values: color, number, dimension, duration, fontWeight, fontFamily, fontStyle, string, boolean.
-Hex formats: #RGB, #RGBA, #RRGGBB, #RRGGBBAA. Dimension values like "8px" or "1.5rem" have units stripped.
+Hex formats: #RGB, #RGBA, #RRGGBB, #RRGGBBAA. Dimension "8px" strips units; "1.5rem" converts to px (assumes 1rem=16px, warned).
+Aliases like "{color.primary.500}" are NOT resolved — they appear as errors. Composite types (typography, shadow, etc.) are skipped with errors.
 Scopes are inferred from path segments (e.g. "fill"→ALL_FILLS, "radius"→CORNER_RADIUS, "spacing"→GAP, "font-size"→FONT_SIZE).`,
   {
     tokens: z
@@ -430,9 +460,11 @@ Scopes are inferred from path segments (e.g. "fill"→ALL_FILLS, "radius"→CORN
 
       // Walk the DTCG tree
       const parsed: ParsedVariable[] = [];
-      walkDtcgTree(params.tokens, [], prefix, undefined, parsed);
+      const errors: string[] = [];
+      const warnings: string[] = [];
+      walkDtcgTree(params.tokens, [], prefix, undefined, parsed, errors, warnings);
 
-      if (parsed.length === 0) {
+      if (parsed.length === 0 && errors.length === 0) {
         return {
           content: [{
             type: "text",
@@ -472,6 +504,8 @@ Scopes are inferred from path segments (e.g. "fill"→ALL_FILLS, "radius"→CORN
             totalVariables: parsed.length,
             totalBatches: batches.length,
             batchSize,
+            ...(errors.length > 0 && { errors }),
+            ...(warnings.length > 0 && { warnings }),
             batches,
           }),
         }],

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -1,0 +1,265 @@
+import { describe, test, expect } from "bun:test";
+import {
+  hexToRgba,
+  dtcgTypeToFigma,
+  convertValue,
+  inferScopes,
+  walkDtcgTree,
+} from "../src/figmagent_mcp/tools/tokens.js";
+
+// ─── hexToRgba ────────────────────────────────────────────────────────────────
+
+describe("hexToRgba", () => {
+  test("parses 6-char hex", () => {
+    const result = hexToRgba("#3366FF");
+    expect(result.r).toBeCloseTo(0.2, 2);
+    expect(result.g).toBeCloseTo(0.4, 2);
+    expect(result.b).toBeCloseTo(1.0, 2);
+    expect(result.a).toBe(1);
+  });
+
+  test("parses 3-char hex (expands to 6)", () => {
+    const result = hexToRgba("#369");
+    expect(result.r).toBeCloseTo(0.2, 2);
+    expect(result.g).toBeCloseTo(0.4, 2);
+    expect(result.b).toBeCloseTo(0.6, 2);
+    expect(result.a).toBe(1);
+  });
+
+  test("parses 8-char hex with alpha", () => {
+    const result = hexToRgba("#FF000080");
+    expect(result.r).toBe(1);
+    expect(result.g).toBe(0);
+    expect(result.b).toBe(0);
+    expect(result.a).toBeCloseTo(0.502, 2);
+  });
+
+  test("parses 4-char hex with alpha (expands to 8)", () => {
+    const result = hexToRgba("#F00F");
+    expect(result.r).toBe(1);
+    expect(result.g).toBe(0);
+    expect(result.b).toBe(0);
+    expect(result.a).toBe(1);
+  });
+
+  test("throws on 5-char hex", () => {
+    expect(() => hexToRgba("#12345")).toThrow("Invalid hex color");
+  });
+
+  test("throws on 7-char hex", () => {
+    expect(() => hexToRgba("#1234567")).toThrow("Invalid hex color");
+  });
+});
+
+// ─── dtcgTypeToFigma ──────────────────────────────────────────────────────────
+
+describe("dtcgTypeToFigma", () => {
+  test("color → COLOR", () => expect(dtcgTypeToFigma("color")).toBe("COLOR"));
+  test("dimension → FLOAT", () => expect(dtcgTypeToFigma("dimension")).toBe("FLOAT"));
+  test("number → FLOAT", () => expect(dtcgTypeToFigma("number")).toBe("FLOAT"));
+  test("duration → FLOAT", () => expect(dtcgTypeToFigma("duration")).toBe("FLOAT"));
+  test("fontWeight → FLOAT", () => expect(dtcgTypeToFigma("fontWeight")).toBe("FLOAT"));
+  test("fontFamily → STRING", () => expect(dtcgTypeToFigma("fontFamily")).toBe("STRING"));
+  test("fontStyle → STRING", () => expect(dtcgTypeToFigma("fontStyle")).toBe("STRING"));
+  test("string → STRING", () => expect(dtcgTypeToFigma("string")).toBe("STRING"));
+  test("boolean → BOOLEAN", () => expect(dtcgTypeToFigma("boolean")).toBe("BOOLEAN"));
+  test("unknown type → STRING", () => expect(dtcgTypeToFigma("typography")).toBe("STRING"));
+});
+
+// ─── convertValue ─────────────────────────────────────────────────────────────
+
+describe("convertValue", () => {
+  test("converts hex color to RGBA object", () => {
+    const r = convertValue("color", "#3366FF");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect((r.value as { r: number }).r).toBeCloseTo(0.2, 2);
+      expect((r.value as { a: number }).a).toBe(1);
+    }
+  });
+
+  test("rejects DTCG alias reference", () => {
+    const r = convertValue("color", "{color.primary.500}");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("Alias");
+  });
+
+  test("strips px units from dimension", () => {
+    const r = convertValue("dimension", "8px");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe(8);
+  });
+
+  test("converts rem to px with a warning (1rem=16px)", () => {
+    const r = convertValue("dimension", "1.5rem");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value).toBe(24);
+      expect(r.warning).toContain("1rem=16px");
+    }
+  });
+
+  test("rejects 'auto' dimension with error", () => {
+    const r = convertValue("dimension", "auto");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("auto");
+  });
+
+  test("rejects composite typography object", () => {
+    const r = convertValue("typography", { fontFamily: "Inter", fontSize: "16px" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("Composite");
+  });
+
+  test("passes through plain number", () => {
+    const r = convertValue("number", 42);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe(42);
+  });
+
+  test("converts boolean string 'true'", () => {
+    const r = convertValue("boolean", "true");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe(true);
+  });
+
+  test("passes through boolean false", () => {
+    const r = convertValue("boolean", false);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe(false);
+  });
+
+  test("passes through plain string", () => {
+    const r = convertValue("string", "Inter");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe("Inter");
+  });
+});
+
+// ─── inferScopes ──────────────────────────────────────────────────────────────
+
+describe("inferScopes", () => {
+  test("generic color → ALL_FILLS", () => {
+    expect(inferScopes("color/primary/500", "COLOR")).toEqual(["ALL_FILLS"]);
+  });
+
+  test("stroke color → STROKE_COLOR", () => {
+    expect(inferScopes("color/stroke/default", "COLOR")).toEqual(["STROKE_COLOR"]);
+  });
+
+  test("border color → STROKE_COLOR", () => {
+    expect(inferScopes("color/border/default", "COLOR")).toEqual(["STROKE_COLOR"]);
+  });
+
+  test("text color → TEXT_FILL", () => {
+    expect(inferScopes("color/text/primary", "COLOR")).toEqual(["TEXT_FILL"]);
+  });
+
+  test("radius → CORNER_RADIUS", () => {
+    expect(inferScopes("border/radius/sm", "FLOAT")).toEqual(["CORNER_RADIUS"]);
+  });
+
+  test("border/width slash path → STROKE_FLOAT", () => {
+    expect(inferScopes("border/width/sm", "FLOAT")).toEqual(["STROKE_FLOAT"]);
+  });
+
+  test("border-width hyphenated → STROKE_FLOAT", () => {
+    expect(inferScopes("border-width-sm", "FLOAT")).toEqual(["STROKE_FLOAT"]);
+  });
+
+  test("spacing → GAP", () => {
+    expect(inferScopes("spacing/md", "FLOAT")).toEqual(["GAP"]);
+  });
+
+  test("font-size → FONT_SIZE", () => {
+    expect(inferScopes("typography/font-size/base", "FLOAT")).toEqual(["FONT_SIZE"]);
+  });
+
+  test("font-family string → FONT_FAMILY", () => {
+    expect(inferScopes("font-family/base", "STRING")).toEqual(["FONT_FAMILY"]);
+  });
+});
+
+// ─── walkDtcgTree ─────────────────────────────────────────────────────────────
+
+describe("walkDtcgTree", () => {
+  function walk(obj: Record<string, unknown>, prefix = "") {
+    const parsed: Array<{ name: string; type: string; value: unknown; scopes: string[] }> = [];
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    walkDtcgTree(obj, [], prefix, undefined, parsed as never, errors, warnings);
+    return { parsed, errors, warnings };
+  }
+
+  test("extracts a simple color token", () => {
+    const { parsed, errors } = walk({
+      color: { $type: "color", primary: { "500": { $value: "#3366FF" } } },
+    });
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].name).toBe("color/primary/500");
+    expect(parsed[0].type).toBe("COLOR");
+    expect(errors).toHaveLength(0);
+  });
+
+  test("extracts a dimension token", () => {
+    const { parsed } = walk({
+      spacing: { $type: "dimension", sm: { $value: "8px" } },
+    });
+    expect(parsed[0].value).toBe(8);
+    expect(parsed[0].type).toBe("FLOAT");
+  });
+
+  test("strips prefix at segment boundary", () => {
+    const { parsed } = walk(
+      { figma: { color: { $type: "color", primary: { $value: "#FF0000" } } } },
+      "figma",
+    );
+    expect(parsed[0].name).toBe("color/primary");
+  });
+
+  test("does NOT strip prefix mid-segment", () => {
+    const { parsed } = walk(
+      { colorful: { primary: { $type: "color", $value: "#FF0000" } } },
+      "col",
+    );
+    // "col" is not a complete segment of "colorful", so name should be unchanged
+    expect(parsed[0].name).toBe("colorful/primary");
+  });
+
+  test("records error for alias, skips variable", () => {
+    const { parsed, errors } = walk({
+      brand: { primary: { $type: "color", $value: "{color.primary.500}" } },
+    });
+    expect(parsed).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("brand/primary");
+    expect(errors[0]).toContain("Alias");
+  });
+
+  test("records error for composite type, skips variable", () => {
+    const { parsed, errors } = walk({
+      heading: { $type: "typography", $value: { fontFamily: "Inter", fontSize: "24px" } },
+    });
+    expect(parsed).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("heading");
+    expect(errors[0]).toContain("Composite");
+  });
+
+  test("records warning for rem values, still creates variable", () => {
+    const { parsed, warnings } = walk({
+      spacing: { md: { $type: "dimension", $value: "1rem" } },
+    });
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].value).toBe(16);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("1rem=16px");
+  });
+
+  test("inherits $type from parent group", () => {
+    const { parsed } = walk({
+      colors: { $type: "color", brand: { primary: { $value: "#FF0000" } } },
+    });
+    expect(parsed[0].type).toBe("COLOR");
+  });
+});


### PR DESCRIPTION
Adds a server-side tool that converts DTCG-format design tokens into create_variables-ready payloads. Handles hex-to-RGBA conversion, $value/$type parsing, scope inference from path segments, and batch chunking. No Figma connection needed.

Closes #26

https://claude.ai/code/session_01X5z9K2Yt6drKqEWC7NCURV

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- Bullet list of what changed -->

## Checklist

- [ ] `bun run lint` passes
- [ ] `bun run test` passes
- [ ] `bun run build:plugin` succeeds (if plugin source changed)
- [ ] Tested in Figma (if plugin behavior changed)
- [ ] Updated CLAUDE.md (if tool behavior or patterns changed)
