### PR TITLE
fix: improve annotation handling at scale

### DIFF
--- a/src/figma_plugin/src/commands/scan.js
+++ b/src/figma_plugin/src/commands/scan.js
@@ -423,7 +423,7 @@ export async function getAnnotations(params) {
         if ("annotations" in n && n.annotations && n.annotations.length > 0) {
           for (let idx = 0; idx < n.annotations.length; idx++) {
             const a = n.annotations[idx];
-            mergedAnnotations.push({ nodeId: n.id, nodeName: n.name, annotationIndex: idx, annotation: a });
+            mergedAnnotations.push({ nodeId: n.id, nodeName: n.name, annotation: { annotationIndex: idx, ...a } });
           }
         }
         if ("children" in n) {
@@ -534,7 +534,7 @@ export async function setAnnotation(params) {
     console.log("=== setAnnotation Debug Start ===");
     console.log("Input params:", JSON.stringify(params, null, 2));
 
-    const { nodeId, annotationId, labelMarkdown, categoryId, properties } = params;
+    const { nodeId, annotationIndex, labelMarkdown, categoryId, properties } = params;
 
     if (!nodeId) {
       console.error("Validation failed: Missing nodeId");
@@ -591,24 +591,24 @@ export async function setAnnotation(params) {
 
     const existingAnnotations = node.annotations ? node.annotations.slice() : [];
 
-    // If annotationId (index) is provided, replace that specific annotation
-    if (annotationId !== undefined && annotationId !== null) {
-      const idx = typeof annotationId === "string" ? parseInt(annotationId, 10) : annotationId;
-      if (idx >= 0 && idx < existingAnnotations.length) {
-        existingAnnotations[idx] = newAnnotation;
+    // If annotationIndex is provided, replace that specific annotation
+    if (annotationIndex !== undefined && annotationIndex !== null) {
+      if (annotationIndex >= 0 && annotationIndex < existingAnnotations.length) {
+        existingAnnotations[annotationIndex] = newAnnotation;
         node.annotations = existingAnnotations;
-        console.log(`Replaced annotation at index ${idx}`);
+        console.log(`Replaced annotation at index ${annotationIndex}`);
       } else {
-        // Index out of range — append instead
-        node.annotations = existingAnnotations.concat([newAnnotation]);
-        console.log(`annotationId ${idx} out of range (${existingAnnotations.length} existing), appended`);
+        return {
+          success: false,
+          error: `annotationIndex ${annotationIndex} out of range (${existingAnnotations.length} existing annotations)`,
+        };
       }
     } else if (existingAnnotations.length > 0) {
-      // No annotationId provided but node already has annotations — replace the first one
+      // No annotationIndex provided but node already has annotations — replace the first one
       // This prevents the "node already has annotation" validation error
       existingAnnotations[0] = newAnnotation;
       node.annotations = existingAnnotations;
-      console.log("Replaced existing first annotation (no annotationId specified)");
+      console.log("Replaced existing first annotation (no annotationIndex specified)");
     } else {
       // No existing annotations — add new
       node.annotations = [newAnnotation];
@@ -663,7 +663,7 @@ export async function setMultipleAnnotations(params) {
     try {
       console.log("Calling setAnnotation with params:", {
         nodeId: annotation.nodeId,
-        annotationId: annotation.annotationId,
+        annotationIndex: annotation.annotationIndex,
         labelMarkdown: annotation.labelMarkdown,
         categoryId: annotation.categoryId,
         properties: annotation.properties,
@@ -671,7 +671,7 @@ export async function setMultipleAnnotations(params) {
 
       const result = await setAnnotation({
         nodeId: annotation.nodeId,
-        annotationId: annotation.annotationId,
+        annotationIndex: annotation.annotationIndex,
         labelMarkdown: annotation.labelMarkdown,
         categoryId: annotation.categoryId,
         properties: annotation.properties,

--- a/src/figmagent_mcp/tools/comments.ts
+++ b/src/figmagent_mcp/tools/comments.ts
@@ -207,13 +207,15 @@ Categories are only included in the response when annotations are found. To disc
 // Set Annotation Tool
 server.tool(
   "set_annotation",
-  "Create or update an annotation",
+  "Create or update an annotation on a node. If annotationIndex is provided, replaces the annotation at that position (0-based). If omitted and the node already has annotations, replaces the first one. If the node has no annotations, adds a new one.",
   {
     nodeId: z.string().describe("The ID of the node to annotate"),
-    annotationId: z
-      .string()
+    annotationIndex: z
+      .number()
+      .int()
+      .nonnegative()
       .optional()
-      .describe("The ID of the annotation to update (if updating existing annotation)"),
+      .describe("0-based index of the annotation to replace. Returned by get_annotations as annotationIndex. If omitted and the node already has annotations, the first one is replaced."),
     labelMarkdown: z.string().describe("The annotation text in markdown format"),
     categoryId: z.string().optional().describe("The ID of the annotation category"),
     properties: z
@@ -225,11 +227,11 @@ server.tool(
       .optional()
       .describe("Additional properties for the annotation"),
   },
-  async ({ nodeId, annotationId, labelMarkdown, categoryId, properties }: any) => {
+  async ({ nodeId, annotationIndex, labelMarkdown, categoryId, properties }: any) => {
     try {
       const result = await sendCommandToFigma("set_annotation", {
         nodeId,
-        annotationId,
+        annotationIndex,
         labelMarkdown,
         categoryId,
         properties,
@@ -267,10 +269,12 @@ server.tool(
           nodeId: z.string().describe("The ID of the node to annotate"),
           labelMarkdown: z.string().describe("The annotation text in markdown format"),
           categoryId: z.string().optional().describe("The ID of the annotation category"),
-          annotationId: z
-            .string()
+          annotationIndex: z
+            .number()
+            .int()
+            .nonnegative()
             .optional()
-            .describe("The ID of the annotation to update (if updating existing annotation)"),
+            .describe("0-based index of the annotation to replace (from get_annotations). If omitted, replaces the first existing annotation or adds a new one."),
           properties: z
             .array(
               z.object({


### PR DESCRIPTION
- Include annotationIndex in get_annotations response so callers can identify and target specific annotations for updates
- Accept annotationId (index) in set_annotation to replace a specific existing annotation instead of always appending
- When no annotationId is provided but the node already has annotations, replace the first one instead of failing with a validation error
- Pass annotationId through set_multiple_annotations to setAnnotation

Closes #14

https://claude.ai/code/session_01X5z9K2Yt6drKqEWC7NCURV

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- Bullet list of what changed -->

## Checklist

- [ ] `bun run lint` passes
- [ ] `bun run test` passes
- [ ] `bun run build:plugin` succeeds (if plugin source changed)
- [ ] Tested in Figma (if plugin behavior changed)
- [ ] Updated CLAUDE.md (if tool behavior or patterns changed)
