### PR TITLE
fix: Add missing text properties and auto-coerce textAutoResize for F…

### DIFF
--- a/src/figma_plugin/src/commands/apply.js
+++ b/src/figma_plugin/src/commands/apply.js
@@ -193,6 +193,17 @@ async function processNode(op, styleCache) {
     if (op.fontSize !== undefined) {
       node.fontSize = toNumber(op.fontSize, 14);
     }
+
+    // Apply text-specific properties
+    if (op.textAutoResize !== undefined) {
+      node.textAutoResize = op.textAutoResize;
+    }
+    if (op.textTruncation !== undefined) {
+      node.textTruncation = op.textTruncation;
+    }
+    if (op.maxLines !== undefined) {
+      node.maxLines = toNumber(op.maxLines, null);
+    }
   }
 
   // Layout direct values (require layoutMode !== "NONE")
@@ -212,6 +223,15 @@ async function processNode(op, styleCache) {
   }
   if (op.layoutSizingHorizontal !== undefined && "layoutSizingHorizontal" in node) {
     node.layoutSizingHorizontal = op.layoutSizingHorizontal;
+    // Auto-coerce textAutoResize for TEXT nodes to prevent width collapse
+    if (
+      node.type === "TEXT" &&
+      op.layoutSizingHorizontal === "FILL" &&
+      op.textAutoResize === undefined &&
+      node.textAutoResize === "WIDTH_AND_HEIGHT"
+    ) {
+      node.textAutoResize = "HEIGHT";
+    }
   }
   if (op.layoutSizingVertical !== undefined && "layoutSizingVertical" in node) {
     node.layoutSizingVertical = op.layoutSizingVertical;

--- a/src/figma_plugin/src/commands/create.js
+++ b/src/figma_plugin/src/commands/create.js
@@ -98,6 +98,16 @@ export async function create(params) {
       if (spec.fontColor) {
         applyFillColor(node, spec.fontColor);
       }
+      // Apply text-specific properties
+      if (spec.textAutoResize !== undefined) {
+        node.textAutoResize = spec.textAutoResize;
+      }
+      if (spec.textTruncation !== undefined) {
+        node.textTruncation = spec.textTruncation;
+      }
+      if (spec.maxLines !== undefined) {
+        node.maxLines = spec.maxLines;
+      }
     } else if (nodeType === "SVG") {
       if (!spec.svg) throw new Error("SVG type requires an 'svg' property with a valid SVG string");
       node = figma.createNodeFromSvg(spec.svg);
@@ -211,8 +221,30 @@ export async function create(params) {
       if (spec.layoutSizingVertical) node.layoutSizingVertical = spec.layoutSizingVertical;
     }
 
+    // For TEXT nodes, apply layout sizing and handle textAutoResize coercion
+    if (nodeType === "TEXT") {
+      if (spec.layoutSizingHorizontal === "FILL") {
+        node.layoutSizingHorizontal = "FILL";
+        // Auto-coerce textAutoResize to prevent width collapse
+        if (spec.textAutoResize === undefined && node.textAutoResize === "WIDTH_AND_HEIGHT") {
+          node.textAutoResize = "HEIGHT";
+        }
+      } else if (spec.layoutSizingHorizontal) {
+        node.layoutSizingHorizontal = spec.layoutSizingHorizontal;
+      }
+      if (spec.layoutSizingVertical) {
+        node.layoutSizingVertical = spec.layoutSizingVertical;
+      }
+    }
+
     if (parentNode && "layoutMode" in parentNode && parentNode.layoutMode !== "NONE") {
-      if (spec.layoutSizingHorizontal === "FILL") node.layoutSizingHorizontal = "FILL";
+      if (spec.layoutSizingHorizontal === "FILL") {
+        node.layoutSizingHorizontal = "FILL";
+        // Auto-coerce textAutoResize for TEXT nodes to prevent width collapse
+        if (nodeType === "TEXT" && spec.textAutoResize === undefined && node.textAutoResize === "WIDTH_AND_HEIGHT") {
+          node.textAutoResize = "HEIGHT";
+        }
+      }
       if (spec.layoutSizingVertical === "FILL") node.layoutSizingVertical = "FILL";
     }
 

--- a/src/figmagent_mcp/tools/apply.ts
+++ b/src/figmagent_mcp/tools/apply.ts
@@ -56,7 +56,10 @@ const nodeOpSchema: z.ZodType<any> = z.lazy(() =>
     strokeWeight: z.number().positive().optional().describe("Stroke weight"),
     cornerRadius: z.number().min(0).optional().describe("Corner radius"),
     opacity: z.number().min(0).max(1).optional().describe("Node opacity (0-1)"),
-    clipsContent: z.boolean().optional().describe("Clip content (frames only). true = overflow hidden, false = overflow visible."),
+    clipsContent: z
+      .boolean()
+      .optional()
+      .describe("Clip content (frames only). true = overflow hidden, false = overflow visible."),
     width: z.number().positive().optional().describe("Width (resizes the node)"),
     height: z.number().positive().optional().describe("Height (resizes the node)"),
 
@@ -68,6 +71,19 @@ const nodeOpSchema: z.ZodType<any> = z.lazy(() =>
       .describe("Font weight (100-900, e.g. 400=Regular, 600=Semi Bold, 700=Bold). TEXT nodes only."),
     fontSize: z.number().positive().optional().describe("Font size in pixels. TEXT nodes only."),
     fontColor: colorSchema.describe("Font color (convenience alias for fillColor on TEXT nodes)."),
+    textAutoResize: z
+      .enum(["NONE", "WIDTH_AND_HEIGHT", "HEIGHT", "TRUNCATE"])
+      .optional()
+      .describe("How the text box adjusts to fit content. HEIGHT is required for FILL sizing. TEXT nodes only."),
+    textTruncation: z
+      .enum(["DISABLED", "ENDING"])
+      .optional()
+      .describe("Ellipsis truncation when text overflows. ENDING adds '...' at the end. TEXT nodes only."),
+    maxLines: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Max lines before truncation. Requires textTruncation: ENDING. TEXT nodes only."),
 
     // Layout properties
     layoutMode: z.enum(["NONE", "HORIZONTAL", "VERTICAL"]).optional().describe("Auto-layout direction"),
@@ -138,8 +154,8 @@ For multiple nodes:
 
 Change fonts on existing TEXT nodes (never delete and recreate text just to change font):
   { nodes: [
-    { nodeId: "title", fontFamily: "Space Grotesk", fontWeight: 700, fontSize: 32 },
-    { nodeId: "body", fontFamily: "Inter", fontWeight: 400, fontSize: 15, fontColor: { r: 0.3, g: 0.3, b: 0.3 } }
+    { nodeId: "title", fontFamily: "Space Grotesk", fontWeight: 700, fontSize: 32, textAutoResize: "HEIGHT" },
+    { nodeId: "body", fontFamily: "Inter", fontWeight: 400, fontSize: 15, fontColor: { r: 0.3, g: 0.3, b: 0.3 }, textTruncation: "ENDING", maxLines: 3 }
   ]}
 
 For nested structures (mirrors create tool pattern):

--- a/src/figmagent_mcp/tools/create.ts
+++ b/src/figmagent_mcp/tools/create.ts
@@ -50,8 +50,28 @@ const nodeSpecSchema: z.ZodType<any> = z.lazy(() =>
     fontFamily: z.string().optional().describe("Font family (default: Inter)"),
     fontStyle: z.string().optional().describe("Font style (default: Regular)"),
     fontColor: colorSchema,
+    textAutoResize: z
+      .enum(["NONE", "WIDTH_AND_HEIGHT", "HEIGHT", "TRUNCATE"])
+      .optional()
+      .describe(
+        "How the text box adjusts to fit content. HEIGHT is required for FILL sizing. Defaults to WIDTH_AND_HEIGHT.",
+      ),
+    textTruncation: z
+      .enum(["DISABLED", "ENDING"])
+      .optional()
+      .describe("Ellipsis truncation when text overflows. ENDING adds '...' at the end."),
+    maxLines: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Max lines before truncation. Requires textTruncation: ENDING."),
     // SVG-specific (type: SVG)
-    svg: z.string().optional().describe("SVG string for SVG type. Figma parses it into vector nodes. Example: '<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\"><path d=\"M12 2L2 22h20L12 2z\"/></svg>'"),
+    svg: z
+      .string()
+      .optional()
+      .describe(
+        'SVG string for SVG type. Figma parses it into vector nodes. Example: \'<svg width="24" height="24" viewBox="0 0 24 24"><path d="M12 2L2 22h20L12 2z"/></svg>\'',
+      ),
     // Instance-specific (type: INSTANCE)
     componentId: z.string().optional().describe("Node ID of a local COMPONENT to instantiate (for INSTANCE type)"),
     componentKey: z
@@ -107,7 +127,7 @@ For multiple root nodes (e.g. variant components), use the nodes array:
 Each node spec in the array is created in parallel. Use this when building multiple sibling components (e.g. variants before combine_as_variants).
 
 FRAME and COMPONENT nodes support auto-layout (layoutMode, padding, alignment, spacing, sizing), fill/stroke colors, and cornerRadius.
-TEXT nodes support text, fontSize, fontWeight, fontFamily, fontStyle, and fontColor.
+TEXT nodes support text, fontSize, fontWeight, fontFamily, fontStyle, fontColor, textAutoResize, textTruncation, and maxLines.
 RECTANGLE nodes support fillColor, strokeColor, strokeWeight, and cornerRadius. IMPORTANT: RECTANGLE cannot use FILL sizing — use a FRAME with fillColor instead when you need a shape that stretches.
 INSTANCE nodes require componentId or componentKey. Position and parentId work as usual.
 SVG nodes require an svg property with a valid SVG string. Figma parses it into vector nodes inside a frame. Use for icons, illustrations, dividers, arrows, or any shape that needs paths.

--- a/src/figmagent_mcp/tools/tokens.ts
+++ b/src/figmagent_mcp/tools/tokens.ts
@@ -306,11 +306,15 @@ Notes:
           lineHeight: z
             .any()
             .optional()
-            .describe("Line height: 'AUTO', { value, unit }, or number. Unitless < 10 auto-converts to PERCENT (1.5 → 150%). >= 10 treated as PIXELS."),
+            .describe(
+              "Line height: 'AUTO', { value, unit }, or number. Unitless < 10 auto-converts to PERCENT (1.5 → 150%). >= 10 treated as PIXELS.",
+            ),
           letterSpacing: z
             .any()
             .optional()
-            .describe("Letter spacing: { value, unit } or number. |value| < 1 auto-converts to PERCENT (-0.025 → -2.5%). |value| >= 1 treated as PIXELS."),
+            .describe(
+              "Letter spacing: { value, unit } or number. |value| < 1 auto-converts to PERCENT (-0.025 → -2.5%). |value| >= 1 treated as PIXELS.",
+            ),
           paragraphSpacing: z.number().optional().describe("Paragraph spacing in pixels"),
           paragraphIndent: z.number().optional().describe("Paragraph indent in pixels"),
           textDecoration: z.enum(["NONE", "UNDERLINE", "STRIKETHROUGH"]).optional().describe("Text decoration"),
@@ -421,8 +425,14 @@ Multiple operations in one call:
           fontFamily: z.string().optional().describe("New font family for TEXT styles"),
           fontStyle: z.string().optional().describe("New font style for TEXT styles"),
           fontSize: z.number().optional().describe("New font size for TEXT styles"),
-          lineHeight: z.any().optional().describe("New line height: 'AUTO', { value, unit }, or number. Unitless < 10 → PERCENT, >= 10 → PIXELS."),
-          letterSpacing: z.any().optional().describe("New letter spacing: { value, unit } or number. |value| < 1 → PERCENT, >= 1 → PIXELS."),
+          lineHeight: z
+            .any()
+            .optional()
+            .describe("New line height: 'AUTO', { value, unit }, or number. Unitless < 10 → PERCENT, >= 10 → PIXELS."),
+          letterSpacing: z
+            .any()
+            .optional()
+            .describe("New letter spacing: { value, unit } or number. |value| < 1 → PERCENT, >= 1 → PIXELS."),
           paragraphSpacing: z.number().optional().describe("New paragraph spacing"),
           paragraphIndent: z.number().optional().describe("New paragraph indent"),
           textDecoration: z.enum(["NONE", "UNDERLINE", "STRIKETHROUGH"]).optional().describe("New text decoration"),

--- a/tests/connection.test.ts
+++ b/tests/connection.test.ts
@@ -107,7 +107,9 @@ describe("sendCommandToFigma", () => {
   });
 
   test("rejects non-join commands when no channel is joined", async () => {
-    const { connectToFigma, disconnectFromFigma, sendCommandToFigma, pendingRequests } = await import("../src/figmagent_mcp/connection.js");
+    const { connectToFigma, disconnectFromFigma, sendCommandToFigma, pendingRequests } = await import(
+      "../src/figmagent_mcp/connection.js"
+    );
 
     // Ensure clean state — previous test may have left a stale connection
     disconnectFromFigma();


### PR DESCRIPTION
…ILL sizing

Fixes #39: TEXT nodes getting zero width inside auto-layout when textAutoResize conflicts with FILL sizing.

## Changes

### 1. Expose missing text properties
Added support for three TEXT node properties in both `create` and `apply` tools:
- `textAutoResize`: "NONE", "WIDTH_AND_HEIGHT", "HEIGHT", "TRUNCATE"
- `textTruncation`: "DISABLED", "ENDING"
- `maxLines`: number | null

### 2. Auto-coerce textAutoResize in plugin
When TEXT node is set to `layoutSizingHorizontal: "FILL"` and `textAutoResize` is still the conflicting default "WIDTH_AND_HEIGHT", automatically coerce it to "HEIGHT". This matches Figma UI behavior and prevents width collapse.

Auto-coercion happens in:
- `create.js` - during TEXT node creation when FILL sizing is specified
- `apply.js` - when FILL sizing is applied to an existing TEXT node

If user explicitly passes textAutoResize alongside FILL sizing, their explicit value is respected (no coercion).

## Summary

<!-- What does this PR do and why? -->

## Changes

<!-- Bullet list of what changed -->

## Checklist

- [ ] `bun run lint` passes
- [ ] `bun run test` passes
- [ ] `bun run build:plugin` succeeds (if plugin source changed)
- [ ] Tested in Figma (if plugin behavior changed)
- [ ] Updated CLAUDE.md (if tool behavior or patterns changed)
