### PR TITLE
fix: eliminate ToolSearch overhead by providing complete tool catalog upfront

### DIFF
--- a/.claude/agents/figma-discovery.md
+++ b/.claude/agents/figma-discovery.md
@@ -1,7 +1,7 @@
 ---
 name: figma-discovery
 description: Explore and map the current state of a Figma document. Use when the target has 8+ variants, unknown tree depth, or when tree exploration would overflow context. Returns a compact structured JSON summary — never modifies anything. Input must be a JSON object with channelName, nodeId, description, and include array.
-tools: ToolSearch, mcp__Figmagent__join_channel, mcp__Figmagent__get, mcp__Figmagent__scan_text_nodes, mcp__Figmagent__get_local_variables, mcp__Figmagent__get_styles, mcp__Figmagent__get_local_components
+tools: mcp__Figmagent__join_channel, mcp__Figmagent__get, mcp__Figmagent__find, mcp__Figmagent__scan_text_nodes, mcp__Figmagent__get_local_variables, mcp__Figmagent__get_styles, mcp__Figmagent__get_local_components, mcp__Figmagent__get_design_system
 model: sonnet
 ---
 
@@ -13,11 +13,7 @@ You explore Figma documents via tool calls and return structured JSON. You NEVER
 
 1. **Every value must come from a tool response.** If a tool failed or wasn't called, use `null`. A `null` is correct; a fabricated value breaks downstream work. Before returning, verify every ID in your output traces to a specific tool response.
 
-2. **Load tools first.** Your very first action:
-```
-ToolSearch(query: "select:mcp__Figmagent__join_channel,mcp__Figmagent__get,mcp__Figmagent__scan_text_nodes,mcp__Figmagent__get_local_variables,mcp__Figmagent__get_styles,mcp__Figmagent__get_local_components")
-```
-If this fails → return `{"status":"blocked","error":"ToolSearch failed","last_tool":"ToolSearch","recommendation":"Check MCP server connection"}`.
+2. **All tools are pre-loaded.** Your tools (join_channel, get, find, scan_text_nodes, get_local_variables, get_styles, get_local_components, get_design_system) are declared in the agent definition and available immediately — no ToolSearch needed. Start directly with Step 1 (Connect).
 
 ---
 

--- a/.claude/skills/figma-guidelines/SKILL.md
+++ b/.claude/skills/figma-guidelines/SKILL.md
@@ -21,6 +21,31 @@ For deeper coverage on any topic, read the corresponding reference file in `refe
 
 ---
 
+## Figmagent Tool Reference
+
+All tools are available via the `mcp__Figmagent__` prefix. Call them directly — no ToolSearch needed.
+
+| Domain | Tools |
+|--------|-------|
+| **Read & Navigate** | `get_document_info`, `get_selection`, `get`, `find`, `scan_text_nodes`, `scan_nodes_by_types`, `export_node_as_image` |
+| **Create** | `create` |
+| **Modify** | `apply`, `move_node`, `resize_node`, `rename_node`, `delete_node`, `delete_multiple_nodes`, `clone_node`, `clone_and_modify`, `reorder_children` |
+| **Text** | `set_text_content`, `set_multiple_text_contents` |
+| **Components** | `get_local_components`, `combine_as_variants`, `component_properties`, `get_instance_overrides`, `set_instance_overrides` |
+| **Design System** | `get_design_system`, `create_variables`, `update_variables`, `create_styles`, `update_styles` |
+| **Libraries** | `get_library_components`, `search_library_components`, `import_library_component`, `get_component_variants`, `get_library_variables` |
+| **Annotations** | `get_annotations`, `set_annotation`, `set_multiple_annotations` |
+| **Comments** | `get_comments`, `post_comment`, `delete_comment` |
+| **Lint** | `lint_design` |
+| **Connection** | `join_channel`, `get_reactions`, `set_default_connector`, `create_connections`, `set_focus`, `set_selections` |
+
+**Common workflows:**
+- Orient: `get_document_info` → `get_selection` → `get(nodeId, detail="structure", depth=2)`
+- Search & modify: `find(criteria)` → `get(nodeId)` → `apply(nodeId, properties)`
+- Design tokens: `get_design_system` → `apply(nodeId, variables={...})`
+
+---
+
 ## Container Selection: Frame vs Group vs Section
 
 **Use a Frame** for virtually everything — layouts, wrappers, components, anything that needs fills, auto layout, clip content, constraints, or effects. Frames have independent dimensions and children position relative to them.

--- a/.claude/skills/figma-sub-agents/SKILL.md
+++ b/.claude/skills/figma-sub-agents/SKILL.md
@@ -101,7 +101,7 @@ The agent definition lives at `.claude/agents/figma-discovery.md`. It has:
 - A read-only tool set (no create/modify tools)
 - A system prompt with its full workflow and output schema
 
-**Tools available to the agent:** `join_channel`, `get`, `scan_text_nodes`, `get_local_variables`, `get_styles`, `get_local_components` (plus `ToolSearch` to load them). Note: `get_main_component` is no longer needed — `get` includes component metadata in `defs.components`.
+**Tools available to the agent:** `join_channel`, `get`, `find`, `scan_text_nodes`, `get_local_variables`, `get_styles`, `get_local_components`, `get_design_system`. All tools are declared in the agent definition and loaded automatically — no ToolSearch needed. Note: `get_main_component` is no longer needed — `get` includes component metadata in `defs.components`.
 
 ### Spawning the Agent
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ Uncomment the `hostname: "0.0.0.0"` line in `src/socket.ts` to allow connections
 ## Agent Notes
 
 - No need to call `join_channel` manually — the MCP server auto-joins when you issue the first Figma command. If multiple Figma files are open, the first command returns a list of file names; call `join_channel({ channel: "file-name" })` to pick one.
+- **No ToolSearch needed.** The MCP server instructions enumerate all 47 available tools by domain. Sub-agents declare their tools in agent definitions. Call tools directly by name instead of discovering them at runtime.
 - Call `get_document_info` first to understand the design structure
 - Use `find` to search for nodes by criteria (component usage, variable bindings, style usage, text content, name, type) — returns grouped matches with ancestry paths
 - Use `get(nodeId, detail="structure", depth=2)` on a target node to orient before making modifications

--- a/src/figmagent_mcp/instance.ts
+++ b/src/figmagent_mcp/instance.ts
@@ -29,6 +29,21 @@ const instructions = `Figmagent bridges AI agents with Figma via a WebSocket rel
 - apply() with textStyleId/effectStyleId — apply styles from the design system
 - lint_design() — scan for unbound properties, auto-fix exact matches
 
+## Available Tools
+
+All 47 tools provided by this server, grouped by domain:
+
+**Reading & Navigation:** get_document_info, get_selection, get, find, scan_text_nodes, scan_nodes_by_types, export_node_as_image
+**Creating:** create
+**Modifying:** apply, move_node, resize_node, rename_node, delete_node, delete_multiple_nodes, clone_node, clone_and_modify, reorder_children
+**Text:** set_text_content, set_multiple_text_contents
+**Components:** get_local_components, combine_as_variants, component_properties, get_instance_overrides, set_instance_overrides
+**Design System:** get_design_system, create_variables, update_variables, create_styles, update_styles
+**Libraries:** get_library_components, search_library_components, import_library_component, get_component_variants, get_library_variables
+**Annotations & Comments:** get_annotations, set_annotation, set_multiple_annotations, get_comments, post_comment, delete_comment
+**Linting:** lint_design
+**Connections & Prototyping:** join_channel, get_reactions, set_default_connector, create_connections, set_focus, set_selections
+
 ## Prompts Available
 Request these for detailed workflow guidance:
 - design_workflow — full 6-phase workflow with examples and pitfalls


### PR DESCRIPTION
Cherry-picked from #24 (first commit only). Drops the second commit which added `get_component_variants_batch` — that functionality was already merged via #32 using the `componentSetNodeIds` param approach.

## Summary
- MCP server instructions now enumerate all 47 tools by domain, so agents know what's available at session start without any ToolSearch calls
- Discovery sub-agent no longer depends on ToolSearch — tools are declared in the agent definition and available immediately
- figma-guidelines skill includes a full tool reference table

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)