### PR TITLE
Fix #62: lint_design crash on gradient / mixed fills

### DIFF
--- a/src/figma_plugin/src/commands/lint.js
+++ b/src/figma_plugin/src/commands/lint.js
@@ -399,8 +399,9 @@ export function checkColorProperty(node, propName, spec, indexes, nodeContext) {
   // Guard: a node may have no paints, or paints may be figma.mixed (a Symbol —
   // common on root frames / sections / mixed-fill nodes). Indexing a Symbol
   // yields undefined, which then crashes on `paint.type` ("cannot read property
-  // 'type' of undefined"). Bail out cleanly instead of dereferencing.
-  if (!paints || typeof paints === "symbol" || !Array.isArray(paints) || paints.length === 0) return null;
+  // 'type' of undefined"). `!Array.isArray(paints)` rejects null/undefined and
+  // the figma.mixed Symbol alike (neither is an array), so it covers issue #62.
+  if (!Array.isArray(paints) || paints.length === 0) return null;
 
   const paint = paints[0];
   if (!paint || typeof paint !== "object") return null;

--- a/src/figma_plugin/src/commands/lint.js
+++ b/src/figma_plugin/src/commands/lint.js
@@ -393,15 +393,21 @@ export function matchVariable(value, property, nodeContext, variables) {
   };
 }
 
-function checkColorProperty(node, propName, spec, indexes, nodeContext) {
+export function checkColorProperty(node, propName, spec, indexes, nodeContext) {
   const fieldName = spec.field;
-  if (!(fieldName in node)) return null;
-
-  const paints = node[fieldName];
-  if (!paints || paints.length === 0) return null;
+  const paints = prop(node, fieldName);
+  // Guard: a node may have no paints, or paints may be figma.mixed (a Symbol —
+  // common on root frames / sections / mixed-fill nodes). Indexing a Symbol
+  // yields undefined, which then crashes on `paint.type` ("cannot read property
+  // 'type' of undefined"). Bail out cleanly instead of dereferencing.
+  if (!paints || typeof paints === "symbol" || !Array.isArray(paints) || paints.length === 0) return null;
 
   const paint = paints[0];
-  if (paint.type !== "SOLID") return null;
+  if (!paint || typeof paint !== "object") return null;
+  // Only SOLID paints carry a single `color` we can match against a variable.
+  // GRADIENT_* / IMAGE / VIDEO paints have no solid `color` (gradients carry
+  // `gradientStops` instead) — skip them rather than dereferencing undefined.
+  if (prop(paint, "type") !== "SOLID") return null;
 
   // Check if already bound
   if (paint.boundVariables && paint.boundVariables.color) {
@@ -409,6 +415,7 @@ function checkColorProperty(node, propName, spec, indexes, nodeContext) {
   }
 
   const color = paint.color;
+  if (!color || typeof color !== "object") return null;
   const m = matchVariable({ r: color.r, g: color.g, b: color.b }, propName, nodeContext, indexes);
   const hexVal = rgbaToHex({ r: color.r, g: color.g, b: color.b, a: paint.opacity !== undefined ? paint.opacity : 1 });
 

--- a/tests/minilint.test.ts
+++ b/tests/minilint.test.ts
@@ -85,9 +85,16 @@ describe("matchVariable", () => {
 });
 
 // Issue #62: lint_design crashed with "cannot read property 'type' of undefined"
-// on root frames / pages / sections whose fills are gradients or figma.mixed.
-// checkColorProperty must tolerate every non-SOLID paint shape without throwing.
-describe("checkColorProperty (issue #62 — gradient / mixed / undefined fills)", () => {
+// on root frames / pages / sections whose fills are `figma.mixed` (a Symbol).
+// Indexing a Symbol yields `undefined`, and the old code then read `.type` off it.
+//
+// NOTE on coverage: the GRADIENT_LINEAR / IMAGE tests below do NOT reproduce #62 —
+// those paints carry a `.type`, so the pre-fix `paint.type !== "SOLID"` check
+// already returned null for them. They guard the SOLID-only contract, not the
+// crash. The genuine #62 regression guard is the `figma.mixed (a Symbol)` test,
+// which asserts both that checkColorProperty no longer throws AND that the
+// pre-fix idiom (indexing the Symbol, then reading `.type`) is what crashed.
+describe("checkColorProperty (issue #62 — figma.mixed Symbol fills; also non-SOLID paints)", () => {
   const fillsSpec = { type: "color", field: "fills" };
   const vars = indexes([colorEntry({ r: 0.96, g: 0.96, b: 0.98 })]);
   const ctx = { nodeType: "FRAME", threshold: 5.0 };
@@ -109,10 +116,15 @@ describe("checkColorProperty (issue #62 — gradient / mixed / undefined fills)"
     expect(checkColorProperty(node, "fills", fillsSpec, vars, ctx)).toBeNull();
   });
 
-  test("figma.mixed fills (a Symbol) is skipped, not indexed into", () => {
+  test("figma.mixed fills (a Symbol) is skipped, not indexed into — the genuine #62 guard", () => {
     const node = { type: "FRAME", fills: Symbol("figma.mixed") };
     expect(() => checkColorProperty(node, "fills", fillsSpec, vars, ctx)).not.toThrow();
     expect(checkColorProperty(node, "fills", fillsSpec, vars, ctx)).toBeNull();
+    // Pin the exact pre-fix crash this guard prevents: indexing the Symbol gives
+    // `undefined`, and reading `.type` off it throws. If a future refactor drops
+    // the guard and re-indexes, the not-throw assertion above starts failing.
+    const paints = node.fills as unknown as { type: string }[];
+    expect(() => paints[0].type).toThrow();
   });
 
   test("missing fills field returns null", () => {

--- a/tests/minilint.test.ts
+++ b/tests/minilint.test.ts
@@ -3,7 +3,7 @@
 // without a live Figma.
 
 import { describe, expect, test } from "bun:test";
-import { matchVariable, rgbToLab } from "../src/figma_plugin/src/commands/lint.js";
+import { checkColorProperty, matchVariable, rgbToLab } from "../src/figma_plugin/src/commands/lint.js";
 
 function colorEntry(overrides: Record<string, unknown>) {
   const r = (overrides.r as number) ?? 0.5;
@@ -81,5 +81,70 @@ describe("matchVariable", () => {
   test("unknown property returns null", () => {
     const m = matchVariable(8, "notAProperty", { nodeType: "FRAME" }, indexes());
     expect(m).toBeNull();
+  });
+});
+
+// Issue #62: lint_design crashed with "cannot read property 'type' of undefined"
+// on root frames / pages / sections whose fills are gradients or figma.mixed.
+// checkColorProperty must tolerate every non-SOLID paint shape without throwing.
+describe("checkColorProperty (issue #62 — gradient / mixed / undefined fills)", () => {
+  const fillsSpec = { type: "color", field: "fills" };
+  const vars = indexes([colorEntry({ r: 0.96, g: 0.96, b: 0.98 })]);
+  const ctx = { nodeType: "FRAME", threshold: 5.0 };
+
+  test("GRADIENT_LINEAR paint is skipped (returns null, no throw)", () => {
+    const node = {
+      type: "FRAME",
+      fills: [
+        {
+          type: "GRADIENT_LINEAR",
+          gradientStops: [
+            { position: 0, color: { r: 1, g: 0, b: 0, a: 1 } },
+            { position: 1, color: { r: 0, g: 0, b: 1, a: 1 } },
+          ],
+        },
+      ],
+    };
+    expect(() => checkColorProperty(node, "fills", fillsSpec, vars, ctx)).not.toThrow();
+    expect(checkColorProperty(node, "fills", fillsSpec, vars, ctx)).toBeNull();
+  });
+
+  test("figma.mixed fills (a Symbol) is skipped, not indexed into", () => {
+    const node = { type: "FRAME", fills: Symbol("figma.mixed") };
+    expect(() => checkColorProperty(node, "fills", fillsSpec, vars, ctx)).not.toThrow();
+    expect(checkColorProperty(node, "fills", fillsSpec, vars, ctx)).toBeNull();
+  });
+
+  test("missing fills field returns null", () => {
+    const node = { type: "PAGE" };
+    expect(() => checkColorProperty(node, "fills", fillsSpec, vars, ctx)).not.toThrow();
+    expect(checkColorProperty(node, "fills", fillsSpec, vars, ctx)).toBeNull();
+  });
+
+  test("empty fills array returns null", () => {
+    const node = { type: "FRAME", fills: [] };
+    expect(checkColorProperty(node, "fills", fillsSpec, vars, ctx)).toBeNull();
+  });
+
+  test("IMAGE paint is skipped", () => {
+    const node = { type: "FRAME", fills: [{ type: "IMAGE", imageHash: "abc" }] };
+    expect(() => checkColorProperty(node, "fills", fillsSpec, vars, ctx)).not.toThrow();
+    expect(checkColorProperty(node, "fills", fillsSpec, vars, ctx)).toBeNull();
+  });
+
+  test("SOLID paint still matches a variable (regression: solid behavior unchanged)", () => {
+    const node = { type: "FRAME", fills: [{ type: "SOLID", color: { r: 0.96, g: 0.96, b: 0.98 } }] };
+    const result = checkColorProperty(node, "fills", fillsSpec, vars, ctx);
+    expect(result).not.toBeNull();
+    expect(result.severity).toBe("exact_match");
+    expect(result.suggestedVariable.id).toBe("VariableID:1:1");
+  });
+
+  test("SOLID paint already bound to a variable returns null", () => {
+    const node = {
+      type: "FRAME",
+      fills: [{ type: "SOLID", color: { r: 0.96, g: 0.96, b: 0.98 }, boundVariables: { color: { id: "x" } } }],
+    };
+    expect(checkColorProperty(node, "fills", fillsSpec, vars, ctx)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Fixes `lint_design` crashing with `"Error running lint_design: cannot read property 'type' of undefined"` on root frames, pages, and sections.

## Root cause

`checkColorProperty` in `src/figma_plugin/src/commands/lint.js` read `paints[0].type` unguarded. When a node's `fills` is `figma.mixed` (a Symbol — common on root frames, pages, and multi-fill sections), the `paints.length === 0` guard passed (a Symbol has no `.length`), so `paints[0]` was `undefined` and `paint.type` threw, crashing the entire lint pass. The original "gradient fill" hypothesis from the session was adjacent — the real trigger is non-array / `figma.mixed` paints. `document.js` and `find.js` already guard paints with `Array.isArray` / `typeof !== "symbol"`; lint did not.

## Fix

- Read paints via the `prop()` strict-guard helper.
- Bail unless paints is a **non-empty Array** (rejects Symbols / null / non-arrays).
- Guard that `paint` is an object; read `prop(paint, "type")`.
- Explicitly skip non-SOLID paints (GRADIENT_*, IMAGE, VIDEO) and guard `paint.color`.
- Solid-paint behavior is unchanged. No `?.` / `??` / object spread (Figma VM constraints respected).

## Tests

Exported `checkColorProperty` and added 7 regression cases to `tests/minilint.test.ts`: gradient, `figma.mixed` Symbol, image, empty, missing, already-bound, and solid paints.

## Validation

- `bun run build:plugin` — builds clean (`code.js` is gitignored, not committed)
- `bun run lint` — clean (92 files)
- `bun run test` — 223 pass / 0 fail

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)
