### PR TITLE
Fix #63: fig.bindVariable silently discards scope-mismatch warnings in run_script

### DIFF
--- a/src/figma_plugin/src/commands/apply.js
+++ b/src/figma_plugin/src/commands/apply.js
@@ -88,6 +88,9 @@ function applyStrokeColor(node, colorSpec) {
 // Binds a variable to a node field. Returns a warning object (and skips the
 // bind) when the variable's declared scopes don't cover this field on this
 // node type — Figma's API would accept the bind silently, so we surface it.
+// The warning carries `message` (what happened) and `fix` (how to resolve) as
+// separate structured fields, so consumers (apply.js batch path, the stdlib
+// fig.bindVariable throw path) never have to parse a fix back out of a string.
 export async function bindVariableToNode(node, field, variableId) {
   const variable = await figma.variables.getVariableByIdAsync(variableId);
   if (!variable)
@@ -123,7 +126,8 @@ export async function bindVariableToNode(node, field, variableId) {
           scopes.join(", ") +
           "], which don't cover this field (needs one of: " +
           requiredScopes.join(", ") +
-          "). Fix: bind a variable scoped for this field, or widen the variable's scopes with update_variables.",
+          ")",
+        fix: "bind a variable scoped for this field, or widen the variable's scopes with update_variables",
       };
     }
   }
@@ -504,7 +508,15 @@ async function processNode(op, styleCache, ctx) {
     const fields = Object.keys(op.variables);
     for (let i = 0; i < fields.length; i++) {
       const bindWarning = await bindVariableToNode(node, fields[i], op.variables[fields[i]]);
-      if (bindWarning) warnings.push(bindWarning);
+      if (bindWarning) {
+        // Fold the structured `fix` back into `message` for the warnings block,
+        // which renders `message` only (formatWarningsBlock in utils.ts).
+        if (bindWarning.fix) {
+          bindWarning.message = bindWarning.message + ". Fix: " + bindWarning.fix;
+          delete bindWarning.fix;
+        }
+        warnings.push(bindWarning);
+      }
     }
   }
 

--- a/src/figma_plugin/src/remote_entries/stdlib.js
+++ b/src/figma_plugin/src/remote_entries/stdlib.js
@@ -36,14 +36,16 @@ globalThis.fig = {
   // continues — a run_script caller has no warnings channel: a returned warning
   // would be silently discarded and a no-op (e.g. an unscoped variable on a
   // stroke) would masquerade as success. So throw with the stated fix instead.
+  //
+  // MUST be awaited: this returns a Promise and the scope-mismatch guard throws
+  // *inside* it. A script that calls it without `await` swallows the rejection
+  // and the skipped-bind no-op silently masquerades as success again (issue #63).
+  // bindVariableToNode returns structured { message, fix }, so the throw path
+  // forwards both fields to fail() directly — no string round-tripping.
   bindVariable: (node, field, variableId) => {
     return bindVariableToNode(node, field, variableId).then((warning) => {
       if (warning) {
-        const idx = warning.message.indexOf(" Fix: ");
-        if (idx >= 0) {
-          fail(warning.message.slice(0, idx), warning.message.slice(idx + 6));
-        }
-        fail(warning.message, "adjust the variable or field so the bind applies");
+        fail(warning.message, warning.fix || "adjust the variable or field so the bind applies");
       }
       return null;
     });

--- a/src/figma_plugin/src/remote_entries/stdlib.js
+++ b/src/figma_plugin/src/remote_entries/stdlib.js
@@ -6,7 +6,7 @@
 // No optional chaining (?.), nullish coalescing (??), or object spread — this
 // code runs in the remote Figma VM.
 
-import { prop, sanitizeSymbols, loadFontWithFallback } from "../helpers.js";
+import { prop, sanitizeSymbols, loadFontWithFallback, fail } from "../helpers.js";
 import { setCharacters } from "../setcharacters.js";
 import { checkNodes } from "../assertions.js";
 import { getNodeTree } from "../commands/document.js";
@@ -30,9 +30,24 @@ globalThis.fig = {
     return getNodeTree({ nodeId: nodeId, detail: detail || "layout" }).then(sanitizeSymbols);
   },
 
-  // Scope-validated design-token binding (FIELD_MAP fields). Returns a
-  // warning object when the variable's scopes don't cover the field, else null.
-  bindVariable: bindVariableToNode,
+  // Scope-validated design-token binding (FIELD_MAP fields). Binds fill AND
+  // stroke paints via setBoundVariableForPaint (see bindVariableToNode). Unlike
+  // the edit/apply batch path — which collects scope-mismatch warnings and
+  // continues — a run_script caller has no warnings channel: a returned warning
+  // would be silently discarded and a no-op (e.g. an unscoped variable on a
+  // stroke) would masquerade as success. So throw with the stated fix instead.
+  bindVariable: (node, field, variableId) => {
+    return bindVariableToNode(node, field, variableId).then((warning) => {
+      if (warning) {
+        const idx = warning.message.indexOf(" Fix: ");
+        if (idx >= 0) {
+          fail(warning.message.slice(0, idx), warning.message.slice(idx + 6));
+        }
+        fail(warning.message, "adjust the variable or field so the bind applies");
+      }
+      return null;
+    });
+  },
 
   // Post-write structural assertions over node ids → warnings[].
   check: (nodeIds) => checkNodes(nodeIds, {}),

--- a/src/figmagent_mcp/tools/script.ts
+++ b/src/figmagent_mcp/tools/script.ts
@@ -98,13 +98,14 @@ The script runs with top-level await and return, with the fig.* stdlib preloaded
 - fig.setCharacters(node, text) — font-safe text replacement (handles mixed-font nodes)
 - fig.loadFont(family, weightOrStyle) — load a font; numeric weight maps to style (600 → "Semi Bold"), falls back to Inter Regular; returns the loaded FontName
 - fig.serialize(nodeOrId, detail) — FSGN raw tree for a node; detail: "structure" | "layout" | "full"
-- fig.bindVariable(node, field, variableId) — scope-validated design-token binding (fill, stroke, cornerRadius, opacity, padding*, itemSpacing, width, height, fontSize, ...); returns a warning or null
+- fig.bindVariable(node, field, variableId) — scope-validated design-token binding (fill, stroke, cornerRadius, opacity, padding*, itemSpacing, width, height, fontSize, ...). Returns null on a successful bind; THROWS (with a stated fix) when the variable's scopes don't cover the field — a skipped bind aborts the whole atomic script rather than silently no-op'ing. ALWAYS await it: it returns a Promise and the guard throws inside it, so an un-awaited call swallows the rejection and the no-op masquerades as success.
 - fig.check(nodeIds) — post-write structural assertions (zero-width text, 100px balloons, overlaps); returns warnings[]
 - fig.createNode(spec, parentId) — the full write tree builder (two-pass FILL sizing, font loading, no default fills)
 
 Conventions:
 - mode: "read" (default) is enforced by a best-effort static scan for mutating API names; the real protection is per-script rollback — a thrown error means nothing was applied. Mutating scripts MUST pass mode: "write".
 - When a mode: "write" script returns { nodeIds: [...] }, fig.check runs over those ids in the same execution and warnings are appended to the response — so return the ids you created/modified.
+- Atomic rollback + fig.bindVariable: a mode "write" script runs atomically — one thrown error discards ALL prior writes in the script. So a loop that binds many nodes and hits one scope mismatch midway rolls back every earlier bind too. If you need persist-the-good-ones-skip-the-bad behavior, use the edit tool (it collects per-bind warnings and continues), or pre-validate scopes with get_design_system, or split into one run_script per node.
 - Budget: stdlib + your code must fit 49,000 chars combined (~19K for your code).
 - Every script is session-logged in full; recurring scripts become first-class tools.`,
   {

--- a/tests/run-script.test.ts
+++ b/tests/run-script.test.ts
@@ -127,19 +127,80 @@ describe("stdlib bundle", () => {
 
   // Issue #63: fig.bindVariable must bind BOTH fill and stroke paints (via
   // setBoundVariableForPaint) and must throw — not silently return a warning —
-  // when a bind is skipped, so a no-op can't masquerade as success.
-  test("bindVariable binds paints via setBoundVariableForPaint and throws on warnings", async () => {
+  // when a bind is skipped, so a no-op can't masquerade as success. These tests
+  // *execute* the bundled IIFE against a fake `figma` so they exercise the
+  // behavior, not just the bundle's textual shape.
+
+  // Build the stdlib IIFE once and instantiate `fig` against a supplied
+  // `figma`/`globalThis` stub. The bundle attaches to globalThis.fig.
+  async function loadFig(figmaStub: unknown): Promise<{
+    bindVariable: (node: unknown, field: string, variableId: string) => Promise<unknown>;
+  }> {
     const code = await getDomainBundle("stdlib");
-    // The shared bindVariableToNode path routes fill AND stroke paint binding
-    // through the known-good Plugin API.
-    expect(code).toContain("setBoundVariableForPaint");
-    expect(code).toContain("strokes");
-    // The fig.bindVariable wrapper inspects the returned warning and raises it
-    // instead of returning it (a returned warning has a .message; the wrapper
-    // surfaces it through the fail() error helper rather than `return warning`).
-    expect(code).toContain(".message");
-    // The wrapper returns null on success (no warning) — never the warning object.
-    expect(code).toMatch(/bindVariable:\s*\([^)]*\)\s*=>/);
+    const sandboxGlobal: { figma?: unknown; fig?: unknown } = {};
+    // The IIFE reads `globalThis` (we pass our sandbox) and `figma` (a free
+    // variable we provide as a function arg). Return the attached fig surface.
+    const factory = new Function("globalThis", "figma", `${code}\nreturn globalThis.fig;`);
+    return factory(sandboxGlobal, figmaStub) as ReturnType<typeof loadFig> extends Promise<infer T> ? T : never;
+  }
+
+  // A fake variable with the given scopes, plus a `figma` whose paint binder
+  // tags the paint so we can assert the bind actually happened.
+  function makeFigma(scopes: string[]) {
+    const boundPaints: unknown[] = [];
+    return {
+      figma: {
+        variables: {
+          getVariableByIdAsync: async (_id: string) => ({ id: _id, name: "color/primary", scopes }),
+          setBoundVariableForPaint: (paint: object, _f: string, v: { id: string }) => {
+            const bound = Object.assign({}, paint, { boundVariables: { color: { id: v.id } } });
+            boundPaints.push(bound);
+            return bound;
+          },
+        },
+      },
+      boundPaints,
+    };
+  }
+
+  test("bindVariable binds BOTH fill and stroke paints via setBoundVariableForPaint", async () => {
+    // ALL_SCOPES covers both the FRAME fill and the stroke field.
+    const { figma, boundPaints } = makeFigma(["ALL_SCOPES"]);
+    const fig = await loadFig(figma);
+
+    const fillNode = { id: "1:1", type: "FRAME", fills: [{ type: "SOLID", color: { r: 0, g: 0, b: 0 } }] };
+    const strokeNode = { id: "1:2", type: "FRAME", strokes: [{ type: "SOLID", color: { r: 0, g: 0, b: 0 } }] };
+
+    expect(await fig.bindVariable(fillNode, "fill", "VariableID:1")).toBeNull();
+    expect(await fig.bindVariable(strokeNode, "stroke", "VariableID:1")).toBeNull();
+
+    // Both paint binds routed through setBoundVariableForPaint (the #63 fix).
+    expect(boundPaints.length).toBe(2);
+    // And the bound paint was written back onto the node's fills/strokes.
+    expect((fillNode.fills[0] as { boundVariables?: unknown }).boundVariables).toBeDefined();
+    expect((strokeNode.strokes[0] as { boundVariables?: unknown }).boundVariables).toBeDefined();
+  }, 30000);
+
+  test("bindVariable THROWS on a scope mismatch (no silent no-op) with message + fix", async () => {
+    // STROKE_COLOR variable, but we bind it to a fill field → scope mismatch.
+    const { figma, boundPaints } = makeFigma(["STROKE_COLOR"]);
+    const fig = await loadFig(figma);
+    const node = { id: "1:3", type: "FRAME", fills: [{ type: "SOLID", color: { r: 0, g: 0, b: 0 } }] };
+
+    let thrown: Error | null = null;
+    try {
+      await fig.bindVariable(node, "fill", "VariableID:1");
+    } catch (e) {
+      thrown = e as Error;
+    }
+    expect(thrown).not.toBeNull();
+    // The fail() error carries the descriptive message AND the stated fix.
+    expect(thrown!.message).toContain("Skipped binding");
+    expect(thrown!.message).toContain("Fix:");
+    // No double period (the structured {message, fix} fix — issue #74 review).
+    expect(thrown!.message).not.toContain("..");
+    // The mismatched bind was NOT applied (loud failure, not silent no-op).
+    expect(boundPaints.length).toBe(0);
   }, 30000);
 });
 

--- a/tests/run-script.test.ts
+++ b/tests/run-script.test.ts
@@ -124,6 +124,23 @@ describe("stdlib bundle", () => {
       expect(code).toContain(name);
     }
   }, 30000);
+
+  // Issue #63: fig.bindVariable must bind BOTH fill and stroke paints (via
+  // setBoundVariableForPaint) and must throw — not silently return a warning —
+  // when a bind is skipped, so a no-op can't masquerade as success.
+  test("bindVariable binds paints via setBoundVariableForPaint and throws on warnings", async () => {
+    const code = await getDomainBundle("stdlib");
+    // The shared bindVariableToNode path routes fill AND stroke paint binding
+    // through the known-good Plugin API.
+    expect(code).toContain("setBoundVariableForPaint");
+    expect(code).toContain("strokes");
+    // The fig.bindVariable wrapper inspects the returned warning and raises it
+    // instead of returning it (a returned warning has a .message; the wrapper
+    // surfaces it through the fail() error helper rather than `return warning`).
+    expect(code).toContain(".message");
+    // The wrapper returns null on success (no warning) — never the warning object.
+    expect(code).toMatch(/bindVariable:\s*\([^)]*\)\s*=>/);
+  }, 30000);
 });
 
 describe("script assembly", () => {


### PR DESCRIPTION
## Summary

Fixes `run_script`'s `fig.bindVariable` silently reporting success when a variable bind was actually skipped — the failure mode behind "124 strokes bound, 0 skipped" leaving every stroke unchanged.

## Root cause (refined from the issue)

The paint-binding code in `bindVariableToNode` (`apply.js`) was already correct — it binds both fill *and* stroke paints via `figma.variables.setBoundVariableForPaint` on a cloned paints array. The real bug is the **silent no-op**: when a variable's scopes don't cover the target field (e.g. a neutral color variable applied to a `STROKE_COLOR` paint), `bindVariableToNode` *returns* a `scope_mismatch` warning instead of binding. The `edit`/`apply` batch path collects those warnings deliberately — but `fig.bindVariable` in `run_script` passed the return value straight back to the user script, which discarded it, so a skipped bind reported as success.

## Fix

Wrap `fig.bindVariable` in `src/figma_plugin/src/remote_entries/stdlib.js` so a returned warning is thrown via `fail(message, fix)`, surfacing the no-op loudly. `bindVariableToNode`'s warning-returning contract is left intact for the batch path. No `?.` / `??` / object spread.

## Note on code.js

`stdlib.js` is a remote entry bundled at runtime by `bundles.ts`; `code.js` only bundles `main.js`. `bun run build:plugin` correctly produces no `code.js` diff (nothing to regenerate). Verified the runtime stdlib bundle preserves the throwing wrapper, `setBoundVariableForPaint`, and the stroke branch.

## Validation

- `bun run lint` — clean (92 files)
- `bun run test` — 217 pass / 0 fail
- `bun run build:plugin` — builds clean; no `code.js` change

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)
