### PR TITLE
Fix #52: pre-load current font in update_styles/update_variables before any property write

### DIFF
--- a/src/figma_plugin/src/commands/styles.js
+++ b/src/figma_plugin/src/commands/styles.js
@@ -16,6 +16,44 @@ async function loadFontOrFail(family, style) {
   }
 }
 
+// Load a TEXT style's CURRENT font before writing any property. Figma
+// re-renders the style on any write — even a non-font prop like lineHeight —
+// and rejects writes when the already-assigned font is not loaded (#52).
+// A TextStyle normally carries a single fontName; the figma.mixed guard is
+// defensive (mixed fonts have no single name to load, so there is nothing to
+// pre-load — the per-field write that needs them will surface its own error).
+async function loadCurrentStyleFont(style) {
+  const current = style.fontName;
+  if (current && current !== figma.mixed) {
+    await figma.loadFontAsync({ family: current.family, style: current.style });
+  }
+}
+
+// Load every available style of a font family. Setting a FONT_FAMILY variable
+// re-renders any text bound to it, which throws if the family is not loaded
+// (#52). We don't know which style(s) the bound text uses, so load them all —
+// the family string is all the variable value gives us. Best-effort: an
+// unresolvable family is left to the setValueForMode write to report.
+async function loadFontFamily(family) {
+  if (typeof family !== "string" || family.length === 0) return;
+  let fonts;
+  try {
+    fonts = await figma.listAvailableFontsAsync();
+  } catch (_listErr) {
+    return;
+  }
+  for (let i = 0; i < fonts.length; i++) {
+    const fn = fonts[i].fontName;
+    if (fn && fn.family === family) {
+      try {
+        await figma.loadFontAsync({ family: fn.family, style: fn.style });
+      } catch (_loadErr) {
+        // Ignore individual style load failures; bound text may not use them.
+      }
+    }
+  }
+}
+
 // Coerce a lineHeight value into Figma's { value, unit } format.
 // - "AUTO" → { unit: "AUTO" }
 // - { value, unit } → pass through (already Figma format)
@@ -565,6 +603,14 @@ export async function updateVariables(params) {
             modeByName[collection.modes[m].name] = collection.modes[m].modeId;
           }
 
+          // A FONT_FAMILY variable re-renders bound text on value change, so
+          // both the OLD and NEW font families must be loaded before writing
+          // (#52). Scope detection covers font-family STRING variables.
+          const isFontFamilyVar =
+            variable.resolvedType === "STRING" &&
+            variable.scopes &&
+            variable.scopes.indexOf("FONT_FAMILY") !== -1;
+
           const valueKeys = Object.keys(update.values);
           for (let j = 0; j < valueKeys.length; j++) {
             const modeName = valueKeys[j];
@@ -578,6 +624,11 @@ export async function updateVariables(params) {
               if (!aliasVar) throw new Error("Alias variable not found: " + value.alias);
               variable.setValueForMode(modeId, { type: "VARIABLE_ALIAS", id: aliasVar.id });
             } else {
+              if (isFontFamilyVar) {
+                const oldFamily = variable.valuesByMode ? variable.valuesByMode[modeId] : undefined;
+                if (typeof oldFamily === "string") await loadFontFamily(oldFamily);
+                await loadFontFamily(value);
+              }
               variable.setValueForMode(modeId, value);
             }
           }
@@ -889,7 +940,11 @@ export async function updateStyles(params) {
           style.paints = [paint];
         }
       } else if (styleType === "TEXT") {
-        // Font name change requires loading the font
+        // Writing ANY text-style property re-renders the style, which requires
+        // its current font to be loaded — even non-font props like lineHeight.
+        // (#52) Load the style's existing fontName before touching anything.
+        await loadCurrentStyleFont(style);
+        // Font name change requires loading the new font too.
         if (update.fontFamily !== undefined || update.fontStyle !== undefined) {
           const family = update.fontFamily || style.fontName.family;
           const fStyle = update.fontStyle || style.fontName.style;

--- a/src/figma_plugin/src/commands/styles.js
+++ b/src/figma_plugin/src/commands/styles.js
@@ -25,7 +25,9 @@ async function loadFontOrFail(family, style) {
 async function loadCurrentStyleFont(style) {
   const current = style.fontName;
   if (current && current !== figma.mixed) {
-    await figma.loadFontAsync({ family: current.family, style: current.style });
+    // Use loadFontOrFail so an uninstalled current font yields a fix-stating
+    // message (repo rule) instead of Figma's opaque load error.
+    await loadFontOrFail(current.family, current.style);
   }
 }
 
@@ -34,13 +36,15 @@ async function loadCurrentStyleFont(style) {
 // (#52). We don't know which style(s) the bound text uses, so load them all —
 // the family string is all the variable value gives us. Best-effort: an
 // unresolvable family is left to the setValueForMode write to report.
-async function loadFontFamily(family) {
+async function loadFontFamily(family, fontList) {
   if (typeof family !== "string" || family.length === 0) return;
-  let fonts;
-  try {
-    fonts = await figma.listAvailableFontsAsync();
-  } catch (_listErr) {
-    return;
+  let fonts = fontList;
+  if (!fonts) {
+    try {
+      fonts = await figma.listAvailableFontsAsync();
+    } catch (_listErr) {
+      return;
+    }
   }
   for (let i = 0; i < fonts.length; i++) {
     const fn = fonts[i].fontName;
@@ -605,11 +609,28 @@ export async function updateVariables(params) {
 
           // A FONT_FAMILY variable re-renders bound text on value change, so
           // both the OLD and NEW font families must be loaded before writing
-          // (#52). Scope detection covers font-family STRING variables.
+          // (#52). Scope detection covers font-family STRING variables. An empty
+          // scopes array is Figma's default and is treated as ALL_SCOPES (same
+          // rule as lint.js isScopeCompatible), so a default-scoped STRING
+          // variable still preloads — otherwise the common case (no explicit
+          // scopes) would miss the preload and reproduce #52.
+          const fontScopes =
+            variable.scopes && variable.scopes.length > 0 ? variable.scopes : ["ALL_SCOPES"];
           const isFontFamilyVar =
             variable.resolvedType === "STRING" &&
-            variable.scopes &&
-            variable.scopes.indexOf("FONT_FAMILY") !== -1;
+            (fontScopes.indexOf("FONT_FAMILY") !== -1 || fontScopes.indexOf("ALL_SCOPES") !== -1);
+
+          // Enumerate the installed font list once per update — it is invariant
+          // for the whole call, so loadFontFamily reuses it instead of calling
+          // figma.listAvailableFontsAsync() per family/mode (#52 review).
+          let availableFonts = null;
+          if (isFontFamilyVar) {
+            try {
+              availableFonts = await figma.listAvailableFontsAsync();
+            } catch (_listErr) {
+              availableFonts = null;
+            }
+          }
 
           const valueKeys = Object.keys(update.values);
           for (let j = 0; j < valueKeys.length; j++) {
@@ -622,12 +643,21 @@ export async function updateVariables(params) {
             if (value && typeof value === "object" && value.alias) {
               const aliasVar = await figma.variables.getVariableByIdAsync(value.alias);
               if (!aliasVar) throw new Error("Alias variable not found: " + value.alias);
+              // An alias change re-renders bound text just like a raw-string
+              // change (#52). Preload the OLD family and the alias's resolved
+              // NEW family so setValueForMode doesn't throw on an unloaded font.
+              if (isFontFamilyVar) {
+                const oldFamily = variable.valuesByMode ? variable.valuesByMode[modeId] : undefined;
+                if (typeof oldFamily === "string") await loadFontFamily(oldFamily, availableFonts);
+                const aliasValue = aliasVar.valuesByMode ? aliasVar.valuesByMode[modeId] : undefined;
+                if (typeof aliasValue === "string") await loadFontFamily(aliasValue, availableFonts);
+              }
               variable.setValueForMode(modeId, { type: "VARIABLE_ALIAS", id: aliasVar.id });
             } else {
               if (isFontFamilyVar) {
                 const oldFamily = variable.valuesByMode ? variable.valuesByMode[modeId] : undefined;
-                if (typeof oldFamily === "string") await loadFontFamily(oldFamily);
-                await loadFontFamily(value);
+                if (typeof oldFamily === "string") await loadFontFamily(oldFamily, availableFonts);
+                await loadFontFamily(value, availableFonts);
               }
               variable.setValueForMode(modeId, value);
             }
@@ -946,6 +976,15 @@ export async function updateStyles(params) {
         await loadCurrentStyleFont(style);
         // Font name change requires loading the new font too.
         if (update.fontFamily !== undefined || update.fontStyle !== undefined) {
+          // A mixed-font style has no single fontName to fall back on, so a
+          // partial change (only family OR only style) would leave the other
+          // half undefined. Require both fields in that case.
+          if (style.fontName === figma.mixed && (update.fontFamily === undefined || update.fontStyle === undefined)) {
+            fail(
+              "Style '" + style.name + "' has mixed fonts; a partial font change leaves the other half undefined",
+              "pass BOTH fontFamily and fontStyle to set a single font on a mixed-font text style",
+            );
+          }
           const family = update.fontFamily || style.fontName.family;
           const fStyle = update.fontStyle || style.fontName.style;
           await loadFontOrFail(family, fStyle);

--- a/src/figmagent_mcp/tools/tokens.ts
+++ b/src/figmagent_mcp/tools/tokens.ts
@@ -730,6 +730,7 @@ Update text style properties:
   { updates: [
     { styleId: "S:abc...", fontSize: 24, fontFamily: "Roboto", fontStyle: "Medium" }
   ]}
+  (TEXT: the style's current font is loaded automatically before any write — even a non-font prop like lineHeight — so updates never fail on an unloaded font. For a mixed-font text style, pass BOTH fontFamily and fontStyle to change the font; a partial change is rejected.)
 
 Rename a style:
   { updates: [{ styleId: "S:abc...", name: "Brand/NewName" }] }

--- a/tests/update-font-preload.test.ts
+++ b/tests/update-font-preload.test.ts
@@ -48,14 +48,32 @@ afterAll(() => {
 });
 
 describe("update_styles: preload current font on text styles (#52)", () => {
-  test("updating lineHeight alone loads the style's current font first", async () => {
+  test("updating lineHeight alone loads the style's current font BEFORE the write", async () => {
+    // A getter/setter on lineHeight records the moment of the property write
+    // into the same ordered log as loadedFonts, so we can assert the font was
+    // loaded *before* the re-rendering write — the actual #52 invariant. A
+    // plain "was the font loaded at some point" check would pass even if the
+    // load happened after the write.
+    const events: string[] = [];
+    let lineHeightValue: any;
     const style: any = {
       id: "S:1",
       type: "TEXT",
       name: "Body",
       fontName: { family: "Public Sans", style: "Medium" },
+      get lineHeight() {
+        return lineHeightValue;
+      },
+      set lineHeight(v: any) {
+        events.push("write:lineHeight");
+        lineHeightValue = v;
+      },
     };
     installFigmaMock({ stylesById: { "S:1": style } });
+    (globalThis as any).figma.loadFontAsync = async (font: { family: string; style: string }) => {
+      events.push("load:" + font.family + "/" + font.style);
+      loadedFonts.push({ family: font.family, style: font.style });
+    };
 
     const result = await updateStyles({ updates: [{ styleId: "S:1", lineHeight: 1.5 }] });
 
@@ -64,6 +82,26 @@ describe("update_styles: preload current font on text styles (#52)", () => {
     // The current font must have been loaded before the lineHeight write.
     expect(loadedFonts).toContainEqual({ family: "Public Sans", style: "Medium" });
     expect(style.lineHeight).toEqual({ value: 150, unit: "PERCENT" });
+    // Ordering: the font load precedes the property write.
+    expect(events.indexOf("load:Public Sans/Medium")).toBeLessThan(events.indexOf("write:lineHeight"));
+  });
+
+  test("mixed fontName + partial font change fails with a stated fix", async () => {
+    const style: any = {
+      id: "S:M",
+      type: "TEXT",
+      name: "MixedHeading",
+      fontName: MIXED,
+    };
+    installFigmaMock({ stylesById: { "S:M": style } });
+
+    const result = await updateStyles({ updates: [{ styleId: "S:M", fontStyle: "Bold" }] });
+
+    expect(result.success).toBe(false);
+    expect(result.results[0].success).toBe(false);
+    expect(result.results[0].error).toContain("Fix:");
+    // No undefined-family font was written.
+    expect(style.fontName).toBe(MIXED);
   });
 
   test("mixed fontName does not throw and skips preload gracefully", async () => {
@@ -134,6 +172,106 @@ describe("update_variables: preload font families for FONT_FAMILY variables (#52
     // … and every style of the new family.
     expect(loadedFonts).toContainEqual({ family: "Test Martina Plantijn", style: "Regular" });
     expect(loadedFonts).toContainEqual({ family: "Test Martina Plantijn", style: "Bold" });
+  });
+
+  test('default ["ALL_SCOPES"] font-family variable still preloads families (#52)', async () => {
+    // ["ALL_SCOPES"] is Figma's default for a STRING variable created without
+    // an explicit scopes argument. The old indexOf("FONT_FAMILY") check missed
+    // it, skipping the preload for the common case.
+    const variable: any = {
+      id: "V:3",
+      name: "font/sans",
+      resolvedType: "STRING",
+      scopes: ["ALL_SCOPES"],
+      variableCollectionId: "C:1",
+      valuesByMode: { mode1: "Public Sans" },
+      setValueForMode: () => {},
+    };
+    installFigmaMock({
+      variablesById: { "V:3": variable },
+      collectionsById: { "C:1": { modes: [{ name: "Default", modeId: "mode1" }] } },
+      availableFonts: [
+        { family: "Public Sans", style: "Regular" },
+        { family: "Test Martina Plantijn", style: "Regular" },
+      ],
+    });
+
+    const result = await updateVariables({
+      updates: [{ variableId: "V:3", values: { Default: "Test Martina Plantijn" } }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(loadedFonts).toContainEqual({ family: "Public Sans", style: "Regular" });
+    expect(loadedFonts).toContainEqual({ family: "Test Martina Plantijn", style: "Regular" });
+  });
+
+  test("empty [] scopes (treated as ALL_SCOPES) still preloads families (#52)", async () => {
+    const variable: any = {
+      id: "V:4",
+      name: "font/empty",
+      resolvedType: "STRING",
+      scopes: [],
+      variableCollectionId: "C:1",
+      valuesByMode: { mode1: "Public Sans" },
+      setValueForMode: () => {},
+    };
+    installFigmaMock({
+      variablesById: { "V:4": variable },
+      collectionsById: { "C:1": { modes: [{ name: "Default", modeId: "mode1" }] } },
+      availableFonts: [
+        { family: "Public Sans", style: "Regular" },
+        { family: "Test Martina Plantijn", style: "Bold" },
+      ],
+    });
+
+    await updateVariables({
+      updates: [{ variableId: "V:4", values: { Default: "Test Martina Plantijn" } }],
+    });
+
+    expect(loadedFonts).toContainEqual({ family: "Public Sans", style: "Regular" });
+    expect(loadedFonts).toContainEqual({ family: "Test Martina Plantijn", style: "Bold" });
+  });
+
+  test("alias reassignment of a font-family variable preloads old + resolved new family (#52)", async () => {
+    let setValue: any = null;
+    const variable: any = {
+      id: "V:5",
+      name: "font/heading",
+      resolvedType: "STRING",
+      scopes: ["FONT_FAMILY"],
+      variableCollectionId: "C:1",
+      valuesByMode: { mode1: "Public Sans" },
+      setValueForMode: (_mode: string, value: any) => {
+        setValue = value;
+      },
+    };
+    const aliasTarget: any = {
+      id: "V:alias",
+      name: "font/base",
+      resolvedType: "STRING",
+      scopes: ["FONT_FAMILY"],
+      variableCollectionId: "C:1",
+      valuesByMode: { mode1: "Test Martina Plantijn" },
+    };
+    installFigmaMock({
+      variablesById: { "V:5": variable, "V:alias": aliasTarget },
+      collectionsById: { "C:1": { modes: [{ name: "Default", modeId: "mode1" }] } },
+      availableFonts: [
+        { family: "Public Sans", style: "Regular" },
+        { family: "Test Martina Plantijn", style: "Regular" },
+      ],
+    });
+
+    const result = await updateVariables({
+      updates: [{ variableId: "V:5", values: { Default: { alias: "V:alias" } } }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(setValue).toEqual({ type: "VARIABLE_ALIAS", id: "V:alias" });
+    // Old family (so currently-bound text re-renders) and the alias's resolved
+    // family both loaded before the alias write.
+    expect(loadedFonts).toContainEqual({ family: "Public Sans", style: "Regular" });
+    expect(loadedFonts).toContainEqual({ family: "Test Martina Plantijn", style: "Regular" });
   });
 
   test("non-font-family STRING variable does not trigger font loading", async () => {

--- a/tests/update-font-preload.test.ts
+++ b/tests/update-font-preload.test.ts
@@ -1,0 +1,159 @@
+// Regression tests for #52: update_styles / update_variables must load the
+// target's CURRENT font(s) before writing ANY property, not only when a font
+// field is in the payload. Writing a non-font prop (lineHeight, value, …) to a
+// text style / font-family variable with an unloaded font otherwise throws
+// "Cannot write to node with unloaded font …".
+//
+// These run the plugin-side handlers against a mocked figma global.
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { updateStyles, updateVariables } from "../src/figma_plugin/src/commands/styles.js";
+
+let loadedFonts: Array<{ family: string; style: string }>;
+const MIXED = Symbol("mixed");
+
+function installFigmaMock(options?: {
+  stylesById?: Record<string, any>;
+  variablesById?: Record<string, any>;
+  collectionsById?: Record<string, any>;
+  availableFonts?: Array<{ family: string; style: string }>;
+}) {
+  const stylesById = options?.stylesById ?? {};
+  const variablesById = options?.variablesById ?? {};
+  const collectionsById = options?.collectionsById ?? {};
+  const availableFonts = options?.availableFonts ?? [];
+  (globalThis as any).figma = {
+    mixed: MIXED,
+    getStyleByIdAsync: async (id: string) => stylesById[id] || null,
+    loadFontAsync: async (font: { family: string; style: string }) => {
+      // Mimic Figma: a style/value may reference an unloaded font, but
+      // loadFontAsync resolves for any installed font.
+      loadedFonts.push({ family: font.family, style: font.style });
+    },
+    listAvailableFontsAsync: async () => availableFonts.map((f) => ({ fontName: f })),
+    variables: {
+      getVariableByIdAsync: async (id: string) => variablesById[id] || null,
+      getVariableCollectionByIdAsync: async (id: string) => collectionsById[id] || null,
+    },
+  };
+}
+
+beforeEach(() => {
+  loadedFonts = [];
+  installFigmaMock();
+});
+
+afterAll(() => {
+  delete (globalThis as any).figma;
+});
+
+describe("update_styles: preload current font on text styles (#52)", () => {
+  test("updating lineHeight alone loads the style's current font first", async () => {
+    const style: any = {
+      id: "S:1",
+      type: "TEXT",
+      name: "Body",
+      fontName: { family: "Public Sans", style: "Medium" },
+    };
+    installFigmaMock({ stylesById: { "S:1": style } });
+
+    const result = await updateStyles({ updates: [{ styleId: "S:1", lineHeight: 1.5 }] });
+
+    expect(result.success).toBe(true);
+    expect(result.totalUpdated).toBe(1);
+    // The current font must have been loaded before the lineHeight write.
+    expect(loadedFonts).toContainEqual({ family: "Public Sans", style: "Medium" });
+    expect(style.lineHeight).toEqual({ value: 150, unit: "PERCENT" });
+  });
+
+  test("mixed fontName does not throw and skips preload gracefully", async () => {
+    const style: any = {
+      id: "S:2",
+      type: "TEXT",
+      name: "Mixed",
+      fontName: MIXED,
+    };
+    installFigmaMock({ stylesById: { "S:2": style } });
+
+    const result = await updateStyles({ updates: [{ styleId: "S:2", letterSpacing: 2 }] });
+
+    expect(result.success).toBe(true);
+    // No single font to preload; nothing loaded, but no crash.
+    expect(loadedFonts).toEqual([]);
+  });
+
+  test("font change still loads the new font in addition to the current one", async () => {
+    const style: any = {
+      id: "S:3",
+      type: "TEXT",
+      name: "Heading",
+      fontName: { family: "Inter", style: "Regular" },
+    };
+    installFigmaMock({ stylesById: { "S:3": style } });
+
+    await updateStyles({ updates: [{ styleId: "S:3", fontStyle: "Bold" }] });
+
+    expect(loadedFonts).toContainEqual({ family: "Inter", style: "Regular" });
+    expect(loadedFonts).toContainEqual({ family: "Inter", style: "Bold" });
+    expect(style.fontName).toEqual({ family: "Inter", style: "Bold" });
+  });
+});
+
+describe("update_variables: preload font families for FONT_FAMILY variables (#52)", () => {
+  test("setting a font-family variable's value loads old and new families", async () => {
+    let setValue: any = null;
+    const variable: any = {
+      id: "V:1",
+      name: "font/serif",
+      resolvedType: "STRING",
+      scopes: ["FONT_FAMILY"],
+      variableCollectionId: "C:1",
+      valuesByMode: { mode1: "Public Sans" },
+      setValueForMode: (_mode: string, value: any) => {
+        setValue = value;
+      },
+    };
+    installFigmaMock({
+      variablesById: { "V:1": variable },
+      collectionsById: { "C:1": { modes: [{ name: "Default", modeId: "mode1" }] } },
+      availableFonts: [
+        { family: "Public Sans", style: "Regular" },
+        { family: "Test Martina Plantijn", style: "Regular" },
+        { family: "Test Martina Plantijn", style: "Bold" },
+      ],
+    });
+
+    const result = await updateVariables({
+      updates: [{ variableId: "V:1", values: { Default: "Test Martina Plantijn" } }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(setValue).toBe("Test Martina Plantijn");
+    // Old family loaded (so bound text using it can re-render) …
+    expect(loadedFonts).toContainEqual({ family: "Public Sans", style: "Regular" });
+    // … and every style of the new family.
+    expect(loadedFonts).toContainEqual({ family: "Test Martina Plantijn", style: "Regular" });
+    expect(loadedFonts).toContainEqual({ family: "Test Martina Plantijn", style: "Bold" });
+  });
+
+  test("non-font-family STRING variable does not trigger font loading", async () => {
+    const variable: any = {
+      id: "V:2",
+      name: "label/text",
+      resolvedType: "STRING",
+      scopes: ["TEXT_CONTENT"],
+      variableCollectionId: "C:1",
+      valuesByMode: { mode1: "Hello" },
+      setValueForMode: () => {},
+    };
+    installFigmaMock({
+      variablesById: { "V:2": variable },
+      collectionsById: { "C:1": { modes: [{ name: "Default", modeId: "mode1" }] } },
+      availableFonts: [{ family: "Inter", style: "Regular" }],
+    });
+
+    await updateVariables({ updates: [{ variableId: "V:2", values: { Default: "World" } }] });
+
+    expect(loadedFonts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

`update_styles` (and `update_variables` for font-family variables) failed when updating a **non-font** property of a text style/variable. The handler only loaded a font when a font field was in the update payload, so updating `lineHeight`/`letterSpacing`/etc. alone skipped font loading and the underlying write threw:

> Cannot write to node with unloaded font "Public Sans Medium". Please call figma.loadFontAsync(...)

These surfaced inside the result JSON (`success: false, totalFailed: N`), not as `is_error: true`, so they were easy to miss. Same font-loading class as the import (#20) and create (#30) fixes.

## Fix

- **`update_styles` (TEXT styles)**: a new `loadCurrentStyleFont()` loads the style's current `fontName` before writing **any** property. `figma.mixed` is handled defensively (a TextStyle normally carries a single fontName). The existing font-change path still loads the new font on top.
- **`update_variables` (FONT_FAMILY STRING variables)**: a new `loadFontFamily()` loads every available style of the old and new font families before `setValueForMode`, since changing the value re-renders any bound text. Detection is scoped to STRING variables with the `FONT_FAMILY` scope, so other STRING variables (e.g. `TEXT_CONTENT`) are untouched.

## Plugin JS constraints

No optional chaining, nullish coalescing, or object spread in plugin source. `bun run build:plugin` regenerates `code.js` (gitignored in this repo, so not committed).

## Tests

New `tests/update-font-preload.test.ts` runs the plugin handlers against a mocked `figma` global:
- updating `lineHeight` alone loads the style's current font first
- mixed fontName skips preload without crashing
- font change loads both current and new font
- font-family variable value change loads old + new families (all styles)
- non-font-family STRING variable triggers no font loading

`bun run lint`, `bun run test` (221 pass), and `bun run build:plugin` all green.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
