### PR TITLE
fix: warn on silent sizing no-ops instead of bare success (#50, #53)

### DIFF
--- a/src/figma_plugin/src/assertions.js
+++ b/src/figma_plugin/src/assertions.js
@@ -41,12 +41,12 @@ export function isBalloonFrame(node) {
 }
 
 // Resolve a requested layoutSizing value for one axis from either request
-// shape: the legacy boolean flag (FILL-only, from create.js) or the richer
-// string value (FILL/HUG/FIXED, from apply.js). Returns the requested value
-// string, or null when nothing was requested for this axis.
-function requestedSizingValue(flag, value) {
-  if (typeof value === "string") return value;
-  if (flag === true) return "FILL";
+// shape: the legacy boolean flag (FILL-only, from create.js — true means FILL)
+// or the richer string value (FILL/HUG/FIXED, from apply.js). Returns the
+// requested value string, or null when nothing was requested for this axis.
+function requestedSizingValue(v) {
+  if (typeof v === "string") return v;
+  if (v === true) return "FILL";
   return null;
 }
 
@@ -58,8 +58,9 @@ function requestedSizingValue(flag, value) {
 // requested: {
 //   horizontal: boolean | "FILL" | "HUG" | "FIXED",
 //   vertical:   boolean | "FILL" | "HUG" | "FIXED",
-//   priorWidth?:  number | null,   // dimension before the op (collapse check)
-//   priorHeight?: number | null,
+//   priorWidth?:  number | null,   // dimension before the op; collapse check
+//   priorHeight?: number | null,   // only fires when this is exactly 0
+//                                  // (missing/null = unknown, skipped)
 // }
 // Returns an array of warnings (one per failed axis).
 export function checkSizingRequested(node, requested) {
@@ -69,13 +70,13 @@ export function checkSizingRequested(node, requested) {
   const parentLabel = parent ? parent.id + ' ("' + parent.name + '")' : "the parent";
   const axes = [
     {
-      want: requestedSizingValue(requested.horizontal, requested.horizontal),
+      want: requestedSizingValue(requested.horizontal),
       field: "layoutSizingHorizontal",
       dim: "width",
       prior: requested.priorWidth,
     },
     {
-      want: requestedSizingValue(requested.vertical, requested.vertical),
+      want: requestedSizingValue(requested.vertical),
       field: "layoutSizingVertical",
       dim: "height",
       prior: requested.priorHeight,
@@ -86,7 +87,12 @@ export function checkSizingRequested(node, requested) {
     if (!axis.want) continue;
     const actual = prop(node, axis.field);
 
-    // 1. Value didn't stick — parent isn't auto-layout, sizing is a no-op.
+    // 1. Value didn't stick — Figma reports a different sizing mode than asked.
+    // On the apply path the no-auto-layout case is pre-caught (warn + skip,
+    // never pushed here), so when this fires the parent DOES have auto-layout
+    // and Figma normalized/rejected the requested mode for this node. On the
+    // create boolean path a missing-auto-layout parent is also possible. Offer
+    // both fixes without asserting which one applies.
     if (actual !== undefined && actual !== axis.want) {
       warnings.push({
         nodeId: node.id,
@@ -99,9 +105,9 @@ export function checkSizingRequested(node, requested) {
           node.id +
           " did not apply — it reports " +
           actual +
-          " because parent " +
+          ". Fix: ensure parent " +
           parentLabel +
-          " has no auto-layout. Fix: set layoutMode: 'HORIZONTAL' or 'VERTICAL' on the parent, or give " +
+          " has layoutMode: 'HORIZONTAL' or 'VERTICAL', or give " +
           node.id +
           " an explicit " +
           axis.dim +
@@ -110,13 +116,15 @@ export function checkSizingRequested(node, requested) {
       continue;
     }
 
-    // 2. FILL stuck (or value unreadable) but the dimension is still collapsed
-    // at ~0 — the FILL was a no-op because the node was already broken and the
-    // parent gave it no room to expand into.
-    if (axis.want === "FILL") {
+    // 2. FILL stuck but the dimension is still collapsed at ~0 — the FILL was a
+    // no-op because the node was already collapsed at 0 before the op and the
+    // parent gave it no room to expand into (issue #50). Only fires when a
+    // numeric prior of 0 was explicitly provided: a missing prior (e.g. the
+    // create.js boolean path, which has no "before" — it just made the node) is
+    // "unknown", so skip rather than fabricate a pre-op collapse.
+    if (axis.want === "FILL" && axis.prior === 0) {
       const dimValue = prop(node, axis.dim);
-      const wasZero = axis.prior === 0 || axis.prior === null || axis.prior === undefined;
-      if (typeof dimValue === "number" && dimValue < 2 && wasZero) {
+      if (typeof dimValue === "number" && dimValue < 2) {
         warnings.push({
           nodeId: node.id,
           check: "width_collapse",
@@ -128,7 +136,7 @@ export function checkSizingRequested(node, requested) {
             axis.dim +
             " at " +
             dimValue +
-            "px — the FILL was a no-op (the node was collapsed before the op and got no room). Fix: set " +
+            "px — the FILL was a no-op (the node was already collapsed at 0 before the op and got no room). Fix: set " +
             axis.dim +
             " explicitly (or textAutoResize: 'HEIGHT' on TEXT) in the same apply, then FILL — combine both in one call.",
         });

--- a/src/figma_plugin/src/assertions.js
+++ b/src/figma_plugin/src/assertions.js
@@ -40,43 +40,108 @@ export function isBalloonFrame(node) {
   return heightSizing === "FIXED";
 }
 
-// FILL-requested-but-not-applied: the op asked for FILL sizing but the node
-// reports something else because the parent lacked auto-layout.
-// requested: { horizontal: boolean, vertical: boolean }
+// Resolve a requested layoutSizing value for one axis from either request
+// shape: the legacy boolean flag (FILL-only, from create.js) or the richer
+// string value (FILL/HUG/FIXED, from apply.js). Returns the requested value
+// string, or null when nothing was requested for this axis.
+function requestedSizingValue(flag, value) {
+  if (typeof value === "string") return value;
+  if (flag === true) return "FILL";
+  return null;
+}
+
+// Sizing-requested-but-not-applied / no-op detection. The op asked for a
+// layoutSizing value (FILL/HUG/FIXED) but either the node reports a different
+// value (parent lacked auto-layout — silent no-op, issues #50/#53) or a FILL
+// request left the dimension collapsed at ~0 (already-collapsed width-0 TEXT
+// repair that didn't take — issue #50).
+// requested: {
+//   horizontal: boolean | "FILL" | "HUG" | "FIXED",
+//   vertical:   boolean | "FILL" | "HUG" | "FIXED",
+//   priorWidth?:  number | null,   // dimension before the op (collapse check)
+//   priorHeight?: number | null,
+// }
 // Returns an array of warnings (one per failed axis).
-export function checkFillRequested(node, requested) {
+export function checkSizingRequested(node, requested) {
   const warnings = [];
   if (!requested) return warnings;
   const parent = prop(node, "parent");
   const parentLabel = parent ? parent.id + ' ("' + parent.name + '")' : "the parent";
   const axes = [
-    { flag: requested.horizontal, field: "layoutSizingHorizontal", dim: "width" },
-    { flag: requested.vertical, field: "layoutSizingVertical", dim: "height" },
+    {
+      want: requestedSizingValue(requested.horizontal, requested.horizontal),
+      field: "layoutSizingHorizontal",
+      dim: "width",
+      prior: requested.priorWidth,
+    },
+    {
+      want: requestedSizingValue(requested.vertical, requested.vertical),
+      field: "layoutSizingVertical",
+      dim: "height",
+      prior: requested.priorHeight,
+    },
   ];
   for (let i = 0; i < axes.length; i++) {
     const axis = axes[i];
-    if (!axis.flag) continue;
+    if (!axis.want) continue;
     const actual = prop(node, axis.field);
-    if (actual === "FILL" || actual === undefined) continue;
-    warnings.push({
-      nodeId: node.id,
-      check: "fill_not_applied",
-      message:
-        axis.field +
-        ": 'FILL' on " +
-        node.id +
-        " did not apply — it reports " +
-        actual +
-        " because parent " +
-        parentLabel +
-        " has no auto-layout. Fix: set layoutMode: 'HORIZONTAL' or 'VERTICAL' on the parent, or give " +
-        node.id +
-        " an explicit " +
-        axis.dim +
-        ".",
-    });
+
+    // 1. Value didn't stick — parent isn't auto-layout, sizing is a no-op.
+    if (actual !== undefined && actual !== axis.want) {
+      warnings.push({
+        nodeId: node.id,
+        check: "fill_not_applied",
+        message:
+          axis.field +
+          ": '" +
+          axis.want +
+          "' on " +
+          node.id +
+          " did not apply — it reports " +
+          actual +
+          " because parent " +
+          parentLabel +
+          " has no auto-layout. Fix: set layoutMode: 'HORIZONTAL' or 'VERTICAL' on the parent, or give " +
+          node.id +
+          " an explicit " +
+          axis.dim +
+          ".",
+      });
+      continue;
+    }
+
+    // 2. FILL stuck (or value unreadable) but the dimension is still collapsed
+    // at ~0 — the FILL was a no-op because the node was already broken and the
+    // parent gave it no room to expand into.
+    if (axis.want === "FILL") {
+      const dimValue = prop(node, axis.dim);
+      const wasZero = axis.prior === 0 || axis.prior === null || axis.prior === undefined;
+      if (typeof dimValue === "number" && dimValue < 2 && wasZero) {
+        warnings.push({
+          nodeId: node.id,
+          check: "width_collapse",
+          message:
+            axis.field +
+            ": 'FILL' on " +
+            node.id +
+            " left " +
+            axis.dim +
+            " at " +
+            dimValue +
+            "px — the FILL was a no-op (the node was collapsed before the op and got no room). Fix: set " +
+            axis.dim +
+            " explicitly (or textAutoResize: 'HEIGHT' on TEXT) in the same apply, then FILL — combine both in one call.",
+        });
+      }
+    }
   }
   return warnings;
+}
+
+// Back-compat alias: callers/tests that pass { horizontal, vertical } boolean
+// flags for FILL-only checks. Delegates to checkSizingRequested.
+export function checkFillRequested(node, requested) {
+  return checkSizingRequested(node, requested);
 }
 
 // Font fallback: the resolved fontName.family differs from what the op asked for.
@@ -234,19 +299,22 @@ export async function checkNodes(nodeIds, opts) {
 // ctx: {
 //   nodeIds:           ids created/modified by the op (deleted ids excluded),
 //   explicitHeightIds: ids where the op explicitly set height,
-//   fillRequests:      [{ id, horizontal, vertical }] — FILL sizing the op asked for,
+//   fillRequests:      [{ id, horizontal, vertical }] — legacy boolean FILL requests (create.js),
+//   sizingRequests:    [{ id, horizontal, vertical, priorWidth, priorHeight }] — layoutSizing requests (apply.js),
 //   fontRequests:      [{ id, family }] — font families the op asked for,
 // }
 export async function runPostWriteAssertions(ctx) {
   const warnings = [];
   if (!ctx) return warnings;
 
-  const fillRequests = ctx.fillRequests || [];
-  for (let i = 0; i < fillRequests.length; i++) {
-    const req = fillRequests[i];
+  // Both request lists feed the same checker — the legacy boolean shape and
+  // the richer { value, prior* } shape are both handled by checkSizingRequested.
+  const sizingRequests = (ctx.fillRequests || []).concat(ctx.sizingRequests || []);
+  for (let i = 0; i < sizingRequests.length; i++) {
+    const req = sizingRequests[i];
     const node = await getNodeSafe(req.id);
     if (!node) continue;
-    const ws = checkFillRequested(node, req);
+    const ws = checkSizingRequested(node, req);
     for (let j = 0; j < ws.length; j++) warnings.push(ws[j]);
   }
 

--- a/src/figma_plugin/src/commands/apply.js
+++ b/src/figma_plugin/src/commands/apply.js
@@ -400,6 +400,15 @@ async function processNode(op, styleCache, ctx) {
     }
   }
 
+  // Snapshot dimensions BEFORE the width-0 TEXT recovery (below) or any sizing
+  // mutation runs, so a post-write assertion can tell whether a FILL request
+  // actually changed the dimension (vs. a no-op that left an already-collapsed
+  // width-0 TEXT at 0 — issue #50). Captured here, not just before
+  // layoutSizing*, because the recovery resizes 0→100 and would mask the
+  // collapse the assertion exists to catch.
+  const priorWidth = prop(node, "width");
+  const priorHeight = prop(node, "height");
+
   // Text layout/resize properties (applies to any TEXT node — not gated on font props).
   // Ordered BEFORE layoutSizingHorizontal so coercion and width-recovery happen before
   // FILL is applied: setting FILL on a TEXT node with WIDTH_AND_HEIGHT collapses width to 0,
@@ -480,11 +489,6 @@ async function processNode(op, styleCache, ctx) {
         " an explicit width/height.",
     });
   }
-  // Snapshot dimensions before applying sizing so a post-write assertion can
-  // tell whether a FILL request actually changed the dimension (vs. a no-op
-  // that left an already-collapsed width-0 TEXT node at 0 — issue #50).
-  const priorWidth = prop(node, "width");
-  const priorHeight = prop(node, "height");
   if (op.layoutSizingHorizontal !== undefined && "layoutSizingHorizontal" in node && !sizingContextMissing) {
     node.layoutSizingHorizontal = op.layoutSizingHorizontal;
   }

--- a/src/figma_plugin/src/commands/apply.js
+++ b/src/figma_plugin/src/commands/apply.js
@@ -449,41 +449,56 @@ async function processNode(op, styleCache, ctx) {
   if (op.counterAxisSpacing !== undefined && "counterAxisSpacing" in node) {
     node.counterAxisSpacing = toNumber(op.counterAxisSpacing, 0);
   }
-  // FILL sizing requires an auto-layout parent — pre-check instead of letting
-  // Figma throw mid-op (warn + skip; the rest of the op still applies).
-  const fillBlocked =
-    (op.layoutSizingHorizontal === "FILL" || op.layoutSizingVertical === "FILL") && !parentHasAutoLayout(node);
-  if (fillBlocked) {
+  // layoutSizing* (FILL/HUG/FIXED) only takes effect when the node lives in an
+  // auto-layout context — its PARENT must be an auto-layout frame. Set
+  // otherwise it is a silent no-op (Figma reports success but nothing changes)
+  // — issues #50/#53. layoutMode is applied earlier (Phase 1), so a combined
+  // { layoutMode, layoutSizing* } call on a parent works; but layoutSizing* on
+  // a child whose parent isn't auto-layout (yet) is the wasted-call trap.
+  // Pre-check the parent so we warn + skip instead of letting the no-op (or a
+  // mid-op throw) masquerade as success.
+  const wantsSizing = op.layoutSizingHorizontal !== undefined || op.layoutSizingVertical !== undefined;
+  const sizingContextMissing = wantsSizing && !parentHasAutoLayout(node);
+  if (sizingContextMissing) {
     const blockedParent = prop(node, "parent");
     const parentLabel = blockedParent ? blockedParent.id + ' ("' + blockedParent.name + '")' : "the parent";
+    const requested = [];
+    if (op.layoutSizingHorizontal !== undefined) requested.push("layoutSizingHorizontal");
+    if (op.layoutSizingVertical !== undefined) requested.push("layoutSizingVertical");
     warnings.push({
       nodeId: op.nodeId,
       check: "fill_not_applied",
       message:
-        "FILL sizing on " +
+        requested.join("/") +
+        " on " +
         op.nodeId +
         " skipped — parent " +
         parentLabel +
-        " has no auto-layout. Fix: edit the parent with layoutMode: 'HORIZONTAL' or 'VERTICAL' first, or give " +
+        " has no auto-layout, so the sizing is a silent no-op. Fix: edit the parent with layoutMode: 'HORIZONTAL' " +
+        "or 'VERTICAL' first (combine layoutMode + layoutSizing* in one apply on the parent), or give " +
         op.nodeId +
         " an explicit width/height.",
     });
   }
-  if (op.layoutSizingHorizontal !== undefined && "layoutSizingHorizontal" in node) {
-    if (!(op.layoutSizingHorizontal === "FILL" && fillBlocked)) {
-      node.layoutSizingHorizontal = op.layoutSizingHorizontal;
-      if (op.layoutSizingHorizontal === "FILL" && ctx) {
-        ctx.fillRequests.push({ id: node.id, horizontal: true, vertical: false });
-      }
-    }
+  // Snapshot dimensions before applying sizing so a post-write assertion can
+  // tell whether a FILL request actually changed the dimension (vs. a no-op
+  // that left an already-collapsed width-0 TEXT node at 0 — issue #50).
+  const priorWidth = prop(node, "width");
+  const priorHeight = prop(node, "height");
+  if (op.layoutSizingHorizontal !== undefined && "layoutSizingHorizontal" in node && !sizingContextMissing) {
+    node.layoutSizingHorizontal = op.layoutSizingHorizontal;
   }
-  if (op.layoutSizingVertical !== undefined && "layoutSizingVertical" in node) {
-    if (!(op.layoutSizingVertical === "FILL" && fillBlocked)) {
-      node.layoutSizingVertical = op.layoutSizingVertical;
-      if (op.layoutSizingVertical === "FILL" && ctx) {
-        ctx.fillRequests.push({ id: node.id, horizontal: false, vertical: true });
-      }
-    }
+  if (op.layoutSizingVertical !== undefined && "layoutSizingVertical" in node && !sizingContextMissing) {
+    node.layoutSizingVertical = op.layoutSizingVertical;
+  }
+  if (wantsSizing && !sizingContextMissing && ctx) {
+    ctx.sizingRequests.push({
+      id: node.id,
+      horizontal: op.layoutSizingHorizontal,
+      vertical: op.layoutSizingVertical,
+      priorWidth: typeof priorWidth === "number" ? priorWidth : null,
+      priorHeight: typeof priorHeight === "number" ? priorHeight : null,
+    });
   }
 
   // Phase 2.8: Text content (font-safe replacement via setcharacters.js —
@@ -633,7 +648,7 @@ export async function apply(params) {
   const ctx = {
     modifiedIds: [],
     explicitHeightIds: [],
-    fillRequests: [],
+    sizingRequests: [],
     fontRequests: [],
     rawSets: [],
   };
@@ -704,7 +719,7 @@ export async function apply(params) {
     const assertionWarnings = await runPostWriteAssertions({
       nodeIds: ctx.modifiedIds,
       explicitHeightIds: ctx.explicitHeightIds,
-      fillRequests: ctx.fillRequests,
+      sizingRequests: ctx.sizingRequests,
       fontRequests: ctx.fontRequests,
     });
     for (let wi = 0; wi < assertionWarnings.length; wi++) warnings.push(assertionWarnings[wi]);

--- a/tests/assertions.test.ts
+++ b/tests/assertions.test.ts
@@ -188,6 +188,31 @@ describe("checkSizingRequested", () => {
     expect(warnings.length).toBe(1);
     expect(warnings[0].check).toBe("fill_not_applied");
   });
+
+  test("create.js boolean FILL with NO prior + collapsed width: no width_collapse (unknown prior, skip)", () => {
+    // create.js pushes { id, horizontal, vertical } with no priorWidth. A
+    // freshly-created node has no "before the op", so an unknown prior must not
+    // be treated as zero — otherwise every new collapsed FILL node would wrongly
+    // claim it was collapsed before the op.
+    const warnings = checkSizingRequested(
+      { id: "1:1", type: "TEXT", layoutSizingHorizontal: "FILL", width: 0, parent },
+      { horizontal: true, vertical: false },
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  test("FILL recovery FAILED on apply path (prior 0, still 0 after) — width_collapse fires (#50 headline)", () => {
+    // This mirrors the apply.js path: priorWidth is now captured BEFORE the
+    // width-0 TEXT recovery resize, so a width-0 TEXT whose FILL could not
+    // recover the dimension is reported here as 0 (not the recovery's 100).
+    const warnings = checkSizingRequested(
+      { id: "13:163", type: "TEXT", layoutSizingHorizontal: "FILL", width: 0, parent },
+      { horizontal: "FILL", vertical: undefined, priorWidth: 0, priorHeight: 16 },
+    );
+    expect(warnings.length).toBe(1);
+    expect(warnings[0].check).toBe("width_collapse");
+    expect(warnings[0].message).toContain("already collapsed at 0 before the op");
+  });
 });
 
 describe("checkFontFallback", () => {

--- a/tests/assertions.test.ts
+++ b/tests/assertions.test.ts
@@ -9,6 +9,7 @@ import {
   isNearZeroWidthText,
   isBalloonFrame,
   checkFillRequested,
+  checkSizingRequested,
   checkFontFallback,
 } from "../src/figma_plugin/src/assertions.js";
 
@@ -126,6 +127,66 @@ describe("checkFillRequested", () => {
     );
     expect(warnings.length).toBe(1);
     expect(warnings[0].message).toContain("layoutSizingVertical");
+  });
+});
+
+describe("checkSizingRequested", () => {
+  const parent = { id: "9:9", name: "Card" };
+
+  test("flags a HUG request that did not apply (parent not auto-layout) — #53", () => {
+    const warnings = checkSizingRequested(
+      { id: "1:1", layoutSizingHorizontal: "FIXED", width: 200, parent },
+      { horizontal: "HUG", vertical: undefined, priorWidth: 200, priorHeight: 40 },
+    );
+    expect(warnings.length).toBe(1);
+    expect(warnings[0].check).toBe("fill_not_applied");
+    expect(warnings[0].message).toContain("'HUG'");
+    expect(warnings[0].message).toContain("FIXED");
+    expect(warnings[0].message).toContain("Fix:");
+  });
+
+  test("no warning when the requested value stuck", () => {
+    const warnings = checkSizingRequested(
+      { id: "1:1", layoutSizingHorizontal: "HUG", width: 80, parent },
+      { horizontal: "HUG", vertical: undefined, priorWidth: 80, priorHeight: 40 },
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  test("FILL stuck but width still collapsed at 0 from a prior 0 — width_collapse (#50)", () => {
+    const warnings = checkSizingRequested(
+      { id: "13:163", type: "TEXT", layoutSizingHorizontal: "FILL", width: 0, parent },
+      { horizontal: "FILL", vertical: undefined, priorWidth: 0, priorHeight: 16 },
+    );
+    expect(warnings.length).toBe(1);
+    expect(warnings[0].check).toBe("width_collapse");
+    expect(warnings[0].message).toContain("no-op");
+    expect(warnings[0].message).toContain("Fix:");
+  });
+
+  test("FILL that expanded width past 0 produces no collapse warning", () => {
+    const warnings = checkSizingRequested(
+      { id: "13:163", type: "TEXT", layoutSizingHorizontal: "FILL", width: 132, parent },
+      { horizontal: "FILL", vertical: undefined, priorWidth: 0, priorHeight: 16 },
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  test("FILL collapsed but width was already non-zero before the op — no warning (not a no-op)", () => {
+    const warnings = checkSizingRequested(
+      { id: "1:1", type: "TEXT", layoutSizingHorizontal: "FILL", width: 0, parent },
+      { horizontal: "FILL", vertical: undefined, priorWidth: 120, priorHeight: 16 },
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  test("accepts the legacy boolean FILL request shape (create.js) via checkFillRequested alias", () => {
+    const warnings = checkFillRequested(
+      { id: "1:1", layoutSizingHorizontal: "FIXED", parent },
+      { horizontal: true, vertical: false },
+    );
+    expect(warnings.length).toBe(1);
+    expect(warnings[0].check).toBe("fill_not_applied");
   });
 });
 

--- a/tests/boundary.test.ts
+++ b/tests/boundary.test.ts
@@ -203,6 +203,40 @@ describe("apply: boundary warnings instead of silent skips", () => {
     // Width-0 recovery nudged width off 0 before FILL was applied (so FILL isn't a no-op).
     expect(fakeNodes["13:163"].width).toBeGreaterThan(0);
     expect(fakeNodes["13:163"].layoutSizingHorizontal).toBe("FILL");
+    // Recovery succeeded → no collapse warning.
+    const collapse = (result.warnings || []).filter((w: any) => w.check === "width_collapse");
+    expect(collapse).toEqual([]);
+  });
+
+  test("FILL on a width-0 TEXT where recovery FAILS to grow it: width_collapse fires (#50 ordering)", async () => {
+    // priorWidth must be snapshotted BEFORE the width-0 recovery resize, else
+    // the post-write assertion would see the recovery's value (not 0) and the
+    // collapse warning — the whole point of #50 — could never fire on the apply
+    // path. Here resize is a no-op (FILL/parent gave the TEXT no room), so the
+    // node stays at width 0 and the warning must still fire.
+    fakeNodes["14:200"] = {
+      id: "14:200",
+      type: "TEXT",
+      name: "stuck",
+      width: 0,
+      height: 16,
+      textAutoResize: "HEIGHT",
+      characters: "Hello",
+      layoutSizingHorizontal: "FIXED",
+      parent: { id: "6:6", name: "Cell", type: "FRAME", layoutMode: "HORIZONTAL" },
+      // Recovery and FILL both fail to give the node any width.
+      resize(_w: number, _h: number) {
+        /* no-op: simulates Figma leaving the collapsed TEXT at 0 */
+      },
+    };
+    const result = await apply({
+      nodes: [{ nodeId: "14:200", textAutoResize: "HEIGHT", layoutSizingHorizontal: "FILL" }],
+    });
+    expect(result.successCount).toBe(1);
+    expect(fakeNodes["14:200"].width).toBe(0);
+    const w = (result.warnings || []).find((w: any) => w.check === "width_collapse");
+    expect(w).toBeDefined();
+    expect(w.message).toContain("Fix:");
   });
 
   test("swapVariantId to a non-sibling variant is rejected with the component set named", async () => {

--- a/tests/boundary.test.ts
+++ b/tests/boundary.test.ts
@@ -136,6 +136,75 @@ describe("apply: boundary warnings instead of silent skips", () => {
     expect(fakeNodes["3:3"].layoutSizingHorizontal).toBe("FIXED");
   });
 
+  test("HUG sizing under a non-auto-layout parent warns and is skipped (#53 generalization)", async () => {
+    fakeNodes["4:4"] = {
+      id: "4:4",
+      type: "FRAME",
+      name: "wrapper",
+      width: 200,
+      height: 80,
+      layoutSizingHorizontal: "FIXED",
+      parent: { id: "8:8", name: "Page", type: "FRAME" },
+    };
+    const result = await apply({ nodes: [{ nodeId: "4:4", layoutSizingHorizontal: "HUG" }] });
+    expect(result.successCount).toBe(1);
+    const w = result.warnings.find((w: any) => w.check === "fill_not_applied");
+    expect(w).toBeDefined();
+    expect(w.message).toContain("layoutSizingHorizontal");
+    expect(w.message).toContain("silent no-op");
+    expect(w.message).toContain("Fix:");
+    // The sizing value was NOT applied (no auto-layout parent).
+    expect(fakeNodes["4:4"].layoutSizingHorizontal).toBe("FIXED");
+  });
+
+  test("layoutMode + layoutSizing* combined in one apply: layoutMode applied first, sizing sticks (#53)", async () => {
+    // Parent IS auto-layout, so FILL on the child is valid in one call.
+    fakeNodes["5:5"] = {
+      id: "5:5",
+      type: "FRAME",
+      name: "row",
+      width: 300,
+      height: 40,
+      layoutMode: "NONE",
+      layoutSizingHorizontal: "FIXED",
+      parent: { id: "7:7", name: "Col", type: "FRAME", layoutMode: "VERTICAL" },
+    };
+    const result = await apply({
+      nodes: [{ nodeId: "5:5", layoutMode: "HORIZONTAL", layoutSizingHorizontal: "FILL" }],
+    });
+    expect(result.successCount).toBe(1);
+    // layoutMode (Phase 1) applied before layoutSizing — both stuck.
+    expect(fakeNodes["5:5"].layoutMode).toBe("HORIZONTAL");
+    expect(fakeNodes["5:5"].layoutSizingHorizontal).toBe("FILL");
+    const w = (result.warnings || []).find((w: any) => w.check === "fill_not_applied");
+    expect(w).toBeUndefined();
+  });
+
+  test("FILL on a width-0 TEXT under an auto-layout parent: width-0 recovery resizes before FILL (#50)", async () => {
+    fakeNodes["13:163"] = {
+      id: "13:163",
+      type: "TEXT",
+      name: "label",
+      width: 0,
+      height: 16,
+      textAutoResize: "HEIGHT",
+      characters: "Hello",
+      layoutSizingHorizontal: "FIXED",
+      parent: { id: "6:6", name: "Cell", type: "FRAME", layoutMode: "HORIZONTAL" },
+      resize(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+      },
+    };
+    const result = await apply({
+      nodes: [{ nodeId: "13:163", textAutoResize: "HEIGHT", layoutSizingHorizontal: "FILL" }],
+    });
+    expect(result.successCount).toBe(1);
+    // Width-0 recovery nudged width off 0 before FILL was applied (so FILL isn't a no-op).
+    expect(fakeNodes["13:163"].width).toBeGreaterThan(0);
+    expect(fakeNodes["13:163"].layoutSizingHorizontal).toBe("FILL");
+  });
+
   test("swapVariantId to a non-sibling variant is rejected with the component set named", async () => {
     fakeNodes["i1"] = {
       id: "i1",


### PR DESCRIPTION
## Problem

Two issues in the same family: a `layoutSizing*` change that has **no effect** was reported as bare `{ success: true }`.

- **#50** — `layoutSizingHorizontal: "FILL"` on an already-collapsed width-0 TEXT node was a silent no-op; width stayed 0 but the call succeeded.
- **#53** — generalization: `layoutSizingHorizontal/Vertical` (FILL/HUG/FIXED) silently no-ops when the node's **parent** isn't an auto-layout frame yet, while `apply` returns success. Combining `layoutMode` + `layoutSizing*` in one call already works.

## What was already in place (not duplicated)

- #39's coerce (`WIDTH_AND_HEIGHT` → `HEIGHT` when FILL is first set) and the **width-0 recovery** that nudges a collapsed TEXT node off 0 before locking it. Together these already collapse #50's two-pass repair recipe into one `apply` call. `layoutMode` is also already applied in Phase 1, before `layoutSizing*` in Phase 2 — so the ordering #53 asks for already holds within one call.

The genuinely missing piece was **visibility**: nothing warned when a sizing request left the dimension unchanged.

## Changes

`src/figma_plugin/src/commands/apply.js`
- Generalize the FILL-only parent pre-check to **all** `layoutSizing*` values: when the parent has no auto-layout, warn (`fill_not_applied`) naming the parent + the fix, and skip the set instead of letting the no-op report success (#53).
- Snapshot width/height before applying sizing and record a richer `sizingRequests` entry (requested value + prior dimensions) for post-write assertions.

`src/figma_plugin/src/assertions.js`
- Generalize `checkFillRequested` → `checkSizingRequested`: flags (a) a sizing value that didn't stick (no-op) and (b) a FILL that left the dimension collapsed at ~0 from a prior-0 state, as a `width_collapse` warning with the one-call fix (#50). `checkFillRequested` kept as a back-compat alias so `create.js`'s legacy boolean request shape still works.

## Tests

- Unit: value-mismatch (HUG that didn't apply) and `width_collapse` (FILL stuck but width still 0 from prior 0; no warning when it expanded or when prior was non-zero); legacy boolean shape via the alias.
- Integration (`apply()` on a mocked figma global): #53 HUG no-op under a non-auto-layout parent, combined `layoutMode` + `layoutSizing*` in one call, and the #50 width-0 TEXT repair (recovery resizes off 0 before FILL).

## Verification

- `bun run build:plugin` — OK (`code.js` is a gitignored build artifact)
- `bun run lint` — clean
- `bun run test` — 225 pass / 0 fail

Closes #50
Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)
