### PR TITLE
Fix #56: batch export_node_as_image / screenshot (nodeIds array)

### DIFF
--- a/src/figma_plugin/src/commands/document.js
+++ b/src/figma_plugin/src/commands/document.js
@@ -1,6 +1,6 @@
 // Document, selection, node info, and export commands
 
-import { sendProgressUpdate, generateCommandId, customBase64Encode, rgbaToHex, toNumber, prop } from "../helpers.js";
+import { sendProgressUpdate, generateCommandId, customBase64Encode, rgbaToHex, toNumber, prop, fail } from "../helpers.js";
 
 export async function getDocumentInfo() {
   await figma.currentPage.loadAsync();
@@ -595,14 +595,30 @@ export async function getNodeTree(params) {
   };
 }
 
-export async function exportNodeAsImage(params) {
-  const { nodeId, scale = 1 } = params || {};
-  const format = "PNG";
+// Max nodes accepted in one batch export call.
+const EXPORT_MAX_NODES = 20;
+// Soft cap on total base64 payload (~chars) returned by one call. Roughly 4 MB
+// of image data — well under the MCP server's per-response budget. Once exceeded,
+// remaining nodes are skipped and reported in `truncated` so the caller can
+// re-request them in a follow-up batch.
+const EXPORT_MAX_PAYLOAD_CHARS = 4000000;
 
-  if (!nodeId) {
-    throw new Error("Missing nodeId parameter");
+function mimeTypeForFormat(format) {
+  switch (format) {
+    case "PNG":
+      return "image/png";
+    case "JPG":
+      return "image/jpeg";
+    case "SVG":
+      return "image/svg+xml";
+    case "PDF":
+      return "application/pdf";
+    default:
+      return "application/octet-stream";
   }
+}
 
+async function exportSingleNode(nodeId, format, scale) {
   const node = await figma.getNodeByIdAsync(nodeId);
   if (!node) {
     throw new Error(`Node not found with ID: ${nodeId}`);
@@ -612,41 +628,88 @@ export async function exportNodeAsImage(params) {
     throw new Error(`Node does not support exporting: ${nodeId}`);
   }
 
-  try {
-    const settings = {
-      format: format,
-      constraint: { type: "SCALE", value: scale },
-    };
+  const settings = {
+    format: format,
+    constraint: { type: "SCALE", value: scale },
+  };
 
-    const bytes = await node.exportAsync(settings);
+  const bytes = await node.exportAsync(settings);
+  const base64 = customBase64Encode(bytes);
 
-    let mimeType;
-    switch (format) {
-      case "PNG":
-        mimeType = "image/png";
-        break;
-      case "JPG":
-        mimeType = "image/jpeg";
-        break;
-      case "SVG":
-        mimeType = "image/svg+xml";
-        break;
-      case "PDF":
-        mimeType = "application/pdf";
-        break;
-      default:
-        mimeType = "application/octet-stream";
+  return {
+    nodeId,
+    format,
+    scale,
+    mimeType: mimeTypeForFormat(format),
+    imageData: base64,
+  };
+}
+
+export async function exportNodeAsImage(params) {
+  const p = params || {};
+  const scale = p.scale === undefined ? 1 : p.scale;
+  const format = "PNG";
+
+  // Batch mode: a `nodeIds` array returns images keyed by nodeId.
+  if (p.nodeIds !== undefined) {
+    const nodeIds = p.nodeIds;
+    if (!Array.isArray(nodeIds) || nodeIds.length === 0) {
+      fail("nodeIds must be a non-empty array of node IDs", "Pass nodeIds: [\"1:2\", \"3:4\"] or use a single nodeId.");
+    }
+    if (nodeIds.length > EXPORT_MAX_NODES) {
+      fail(
+        `Too many nodes for one batch export: ${nodeIds.length} (max ${EXPORT_MAX_NODES}).`,
+        `Split nodeIds into batches of ${EXPORT_MAX_NODES} or fewer.`,
+      );
     }
 
-    const base64 = customBase64Encode(bytes);
+    const images = {};
+    const errors = {};
+    const truncated = [];
+    let payloadChars = 0;
 
-    return {
-      nodeId,
+    for (const id of nodeIds) {
+      if (payloadChars >= EXPORT_MAX_PAYLOAD_CHARS) {
+        truncated.push(id);
+        continue;
+      }
+      try {
+        const single = await exportSingleNode(id, format, scale);
+        images[id] = {
+          format: single.format,
+          scale: single.scale,
+          mimeType: single.mimeType,
+          imageData: single.imageData,
+        };
+        payloadChars += single.imageData.length;
+      } catch (error) {
+        errors[id] = error.message;
+      }
+    }
+
+    const result = {
+      batch: true,
       format,
       scale,
-      mimeType,
-      imageData: base64,
+      images,
     };
+    if (Object.keys(errors).length > 0) {
+      result.errors = errors;
+    }
+    if (truncated.length > 0) {
+      result.truncated = truncated;
+    }
+    return result;
+  }
+
+  // Single-node mode (backward compatible).
+  const nodeId = p.nodeId;
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  try {
+    return await exportSingleNode(nodeId, format, scale);
   } catch (error) {
     throw new Error(`Error exporting node as image: ${error.message}`);
   }

--- a/src/figma_plugin/src/commands/document.js
+++ b/src/figma_plugin/src/commands/document.js
@@ -597,9 +597,14 @@ export async function getNodeTree(params) {
 
 // Max nodes accepted in one batch export call.
 const EXPORT_MAX_NODES = 20;
-// Soft cap on total base64 payload (~chars) returned by one call. Roughly 4 MB
-// of image data — well under the MCP server's per-response budget. Once exceeded,
-// remaining nodes are skipped and reported in `truncated` so the caller can
+// Hard ceiling on total base64 payload (~chars) returned by one call. Roughly
+// 4 MB of image data. This is a true ceiling, not a floor: a node is only added
+// if it fits within the remaining budget, so the returned payload never exceeds
+// this cap (the only exception is a single first image larger than the whole
+// cap — see below). Enforcing the ceiling on the plugin side also bounds the
+// remote transport's return payload, where `use_figma` does `JSON.stringify`
+// with no size guard of its own (remote/executor.ts only budgets the input
+// script). Over-budget nodes are reported in `truncated` so the caller can
 // re-request them in a follow-up batch.
 const EXPORT_MAX_PAYLOAD_CHARS = 4000000;
 
@@ -621,11 +626,11 @@ function mimeTypeForFormat(format) {
 async function exportSingleNode(nodeId, format, scale) {
   const node = await figma.getNodeByIdAsync(nodeId);
   if (!node) {
-    throw new Error(`Node not found with ID: ${nodeId}`);
+    fail(`Node not found with ID: ${nodeId}`, "Verify the node ID with `grep` or `read` — it may be stale after a delete.");
   }
 
   if (!("exportAsync" in node)) {
-    throw new Error(`Node does not support exporting: ${nodeId}`);
+    fail(`Node does not support exporting: ${nodeId}`, "Export a node that supports rendering, such as a FRAME, COMPONENT, or GROUP.");
   }
 
   const settings = {
@@ -648,7 +653,7 @@ async function exportSingleNode(nodeId, format, scale) {
 export async function exportNodeAsImage(params) {
   const p = params || {};
   const scale = p.scale === undefined ? 1 : p.scale;
-  const format = "PNG";
+  const format = p.format ? p.format : "PNG";
 
   // Batch mode: a `nodeIds` array returns images keyed by nodeId.
   if (p.nodeIds !== undefined) {
@@ -658,7 +663,7 @@ export async function exportNodeAsImage(params) {
     }
     if (nodeIds.length > EXPORT_MAX_NODES) {
       fail(
-        `Too many nodes for one batch export: ${nodeIds.length} (max ${EXPORT_MAX_NODES}).`,
+        `Too many nodes for one batch export: ${nodeIds.length} (max ${EXPORT_MAX_NODES})`,
         `Split nodeIds into batches of ${EXPORT_MAX_NODES} or fewer.`,
       );
     }
@@ -669,21 +674,27 @@ export async function exportNodeAsImage(params) {
     let payloadChars = 0;
 
     for (const id of nodeIds) {
-      if (payloadChars >= EXPORT_MAX_PAYLOAD_CHARS) {
-        truncated.push(id);
-        continue;
-      }
       try {
         const single = await exportSingleNode(id, format, scale);
+        const imageChars = single.imageData.length;
+        // Enforce the cap AFTER export so it is a true ceiling: only add this
+        // image if it fits in the remaining budget. Always allow the first
+        // image through (images empty) so a single oversized node still
+        // returns one result rather than silently producing nothing.
+        const isFirst = Object.keys(images).length === 0;
+        if (!isFirst && payloadChars + imageChars > EXPORT_MAX_PAYLOAD_CHARS) {
+          truncated.push(id);
+          continue;
+        }
         images[id] = {
           format: single.format,
           scale: single.scale,
           mimeType: single.mimeType,
           imageData: single.imageData,
         };
-        payloadChars += single.imageData.length;
+        payloadChars += imageChars;
       } catch (error) {
-        errors[id] = error.message;
+        errors[id] = error && error.message ? error.message : String(error);
       }
     }
 
@@ -702,15 +713,13 @@ export async function exportNodeAsImage(params) {
     return result;
   }
 
-  // Single-node mode (backward compatible).
+  // Single-node mode (backward compatible). The not-found / unsupported checks
+  // in exportSingleNode already throw descriptive, fix-stated errors, so call
+  // it directly rather than re-wrapping (which would double-prefix the message).
   const nodeId = p.nodeId;
   if (!nodeId) {
-    throw new Error("Missing nodeId parameter");
+    fail("Missing nodeId parameter", "Pass `nodeId` for one node or `nodeIds` for a batch.");
   }
 
-  try {
-    return await exportSingleNode(nodeId, format, scale);
-  } catch (error) {
-    throw new Error(`Error exporting node as image: ${error.message}`);
-  }
+  return await exportSingleNode(nodeId, format, scale);
 }

--- a/src/figmagent_mcp/tools/export.ts
+++ b/src/figmagent_mcp/tools/export.ts
@@ -2,30 +2,90 @@ import { z } from "zod";
 import { server } from "../instance.js";
 import { sendCommandToFigma } from "../connection.js";
 
-// Screenshot Tool — export a node as an image
+type SingleExport = { imageData: string; mimeType: string };
+type BatchExport = {
+  batch: true;
+  format: string;
+  scale: number;
+  images: Record<string, SingleExport>;
+  errors?: Record<string, string>;
+  truncated?: string[];
+};
+
+// Screenshot Tool — export one or many nodes as images
 server.tool(
   "screenshot",
-  "Export a Figma node as an image (PNG/JPG/SVG/PDF). Use for visual spot-checks after building or modifying a design.",
+  "Export Figma node(s) as PNG image(s) for visual spot-checks after building or modifying a design. " +
+    "Pass a single `nodeId` to export one node, OR a `nodeIds` array (max 20) to export many in one call — " +
+    "the batch response interleaves a text marker (nodeId) before each image so results stay keyed by node. " +
+    "Total payload is capped (~4MB); over-budget nodes are listed under `truncated` for a follow-up batch, " +
+    "and per-node export failures are reported without failing the whole call.",
   {
-    nodeId: z.string().describe("The ID of the node to export"),
+    nodeId: z.string().optional().describe("The ID of a single node to export"),
+    nodeIds: z
+      .array(z.string())
+      .max(20)
+      .optional()
+      .describe("Array of node IDs to export in one batch (max 20). Returns images keyed by nodeId."),
     format: z.enum(["PNG", "JPG", "SVG", "PDF"]).optional().describe("Export format"),
     scale: z.coerce.number().positive().optional().describe("Export scale"),
   },
-  async ({ nodeId, format, scale }: any) => {
+  async ({ nodeId, nodeIds, format, scale }: any) => {
+    if (!nodeId && (!nodeIds || nodeIds.length === 0)) {
+      return {
+        content: [{ type: "text", text: "Provide either nodeId (single) or nodeIds (array)." }],
+        isError: true,
+      };
+    }
+
     try {
-      const result = await sendCommandToFigma("export_node_as_image", {
+      // Batch mode
+      if (nodeIds && nodeIds.length > 0) {
+        const result = (await sendCommandToFigma("export_node_as_image", {
+          nodeIds,
+          format: format || "PNG",
+          scale: scale || 1,
+        })) as BatchExport;
+
+        const content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> = [];
+        const ids = Object.keys(result.images || {});
+        content.push({
+          type: "text",
+          text: `Exported ${ids.length} node(s): ${ids.join(", ") || "none"}`,
+        });
+        for (const id of ids) {
+          const img = result.images[id];
+          content.push({ type: "text", text: `nodeId: ${id}` });
+          content.push({ type: "image", data: img.imageData, mimeType: img.mimeType || "image/png" });
+        }
+        if (result.errors && Object.keys(result.errors).length > 0) {
+          content.push({
+            type: "text",
+            text: `Errors: ${JSON.stringify(result.errors)}`,
+          });
+        }
+        if (result.truncated && result.truncated.length > 0) {
+          content.push({
+            type: "text",
+            text: `Truncated (payload cap reached, re-request in a follow-up batch): ${result.truncated.join(", ")}`,
+          });
+        }
+        return { content };
+      }
+
+      // Single mode (backward compatible)
+      const result = (await sendCommandToFigma("export_node_as_image", {
         nodeId,
         format: format || "PNG",
         scale: scale || 1,
-      });
-      const typedResult = result as { imageData: string; mimeType: string };
+      })) as SingleExport;
 
       return {
         content: [
           {
             type: "image",
-            data: typedResult.imageData,
-            mimeType: typedResult.mimeType || "image/png",
+            data: result.imageData,
+            mimeType: result.mimeType || "image/png",
           },
         ],
       };

--- a/src/figmagent_mcp/tools/export.ts
+++ b/src/figmagent_mcp/tools/export.ts
@@ -15,11 +15,11 @@ type BatchExport = {
 // Screenshot Tool — export one or many nodes as images
 server.tool(
   "screenshot",
-  "Export Figma node(s) as PNG image(s) for visual spot-checks after building or modifying a design. " +
-    "Pass a single `nodeId` to export one node, OR a `nodeIds` array (max 20) to export many in one call — " +
-    "the batch response interleaves a text marker (nodeId) before each image so results stay keyed by node. " +
+  "Export Figma node(s) as an image (PNG by default; JPG/SVG/PDF via `format`) for visual spot-checks after building or modifying a design. " +
+    "Pass a single `nodeId` to export one node, OR a `nodeIds` array (max 20) to export many in one call (not both) — " +
+    "the batch response interleaves a text marker (nodeId) before each image so results stay keyed by node; duplicate IDs are de-duped. " +
     "Total payload is capped (~4MB); over-budget nodes are listed under `truncated` for a follow-up batch, " +
-    "and per-node export failures are reported without failing the whole call.",
+    "and per-node export failures are reported without failing the whole call (a batch where every node fails returns isError).",
   {
     nodeId: z.string().optional().describe("The ID of a single node to export"),
     nodeIds: z
@@ -31,18 +31,33 @@ server.tool(
     scale: z.coerce.number().positive().optional().describe("Export scale"),
   },
   async ({ nodeId, nodeIds, format, scale }: any) => {
-    if (!nodeId && (!nodeIds || nodeIds.length === 0)) {
+    const hasBatch = Array.isArray(nodeIds) && nodeIds.length > 0;
+    if (!nodeId && !hasBatch) {
       return {
         content: [{ type: "text", text: "Provide either nodeId (single) or nodeIds (array)." }],
+        isError: true,
+      };
+    }
+    if (nodeId && hasBatch) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "Provide either nodeId (single) or nodeIds (array), not both — they are mutually exclusive.",
+          },
+        ],
         isError: true,
       };
     }
 
     try {
       // Batch mode
-      if (nodeIds && nodeIds.length > 0) {
+      if (hasBatch) {
+        // De-dupe so the plugin's per-id keying stays 1:1; repeated IDs would
+        // otherwise collapse to one key and misreport the exported count.
+        const uniqueIds: string[] = [...new Set<string>(nodeIds)];
         const result = (await sendCommandToFigma("export_node_as_image", {
-          nodeIds,
+          nodeIds: uniqueIds,
           format: format || "PNG",
           scale: scale || 1,
         })) as BatchExport;
@@ -58,7 +73,8 @@ server.tool(
           content.push({ type: "text", text: `nodeId: ${id}` });
           content.push({ type: "image", data: img.imageData, mimeType: img.mimeType || "image/png" });
         }
-        if (result.errors && Object.keys(result.errors).length > 0) {
+        const hasErrors = !!(result.errors && Object.keys(result.errors).length > 0);
+        if (hasErrors) {
           content.push({
             type: "text",
             text: `Errors: ${JSON.stringify(result.errors)}`,
@@ -69,6 +85,12 @@ server.tool(
             type: "text",
             text: `Truncated (payload cap reached, re-request in a follow-up batch): ${result.truncated.join(", ")}`,
           });
+        }
+        // A batch where every node failed exported nothing — surface it as an
+        // error so an agent branching on isError doesn't read total failure as
+        // success.
+        if (ids.length === 0 && hasErrors) {
+          return { content, isError: true };
         }
         return { content };
       }

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -1,0 +1,93 @@
+// Issue #56 — batch export_node_as_image: single-node stays backward compatible,
+// `nodeIds` array returns images keyed by nodeId with per-node errors and a
+// payload cap (truncated list). Runs the plugin handler against a mocked figma.
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { exportNodeAsImage } from "../src/figma_plugin/src/commands/document.js";
+
+let fakeNodes: Record<string, any>;
+
+function makeExportableNode(id: string, byteLen: number) {
+  return {
+    id,
+    type: "FRAME",
+    name: id,
+    exportAsync: async (_settings: any) => new Uint8Array(byteLen),
+  };
+}
+
+function installFigmaMock() {
+  (globalThis as any).figma = {
+    getNodeByIdAsync: async (id: string) => fakeNodes[id] || null,
+  };
+}
+
+beforeEach(() => {
+  fakeNodes = {};
+  installFigmaMock();
+});
+
+afterAll(() => {
+  delete (globalThis as any).figma;
+});
+
+describe("exportNodeAsImage: single-node (backward compatible)", () => {
+  test("exports one node and returns imageData/mimeType", async () => {
+    fakeNodes["1:1"] = makeExportableNode("1:1", 30);
+    const result = await exportNodeAsImage({ nodeId: "1:1" });
+    expect(result.nodeId).toBe("1:1");
+    expect(result.mimeType).toBe("image/png");
+    expect(typeof result.imageData).toBe("string");
+    expect(result.imageData.length).toBeGreaterThan(0);
+    expect((result as any).batch).toBeUndefined();
+  });
+
+  test("missing nodeId throws", async () => {
+    await expect(exportNodeAsImage({})).rejects.toThrow(/Missing nodeId/);
+  });
+
+  test("unknown node throws node-not-found", async () => {
+    await expect(exportNodeAsImage({ nodeId: "9:9" })).rejects.toThrow(/Node not found/);
+  });
+});
+
+describe("exportNodeAsImage: batch mode (nodeIds array)", () => {
+  test("returns images keyed by nodeId", async () => {
+    fakeNodes["1:1"] = makeExportableNode("1:1", 30);
+    fakeNodes["2:2"] = makeExportableNode("2:2", 30);
+    const result = await exportNodeAsImage({ nodeIds: ["1:1", "2:2"] });
+    expect(result.batch).toBe(true);
+    expect(Object.keys(result.images)).toEqual(["1:1", "2:2"]);
+    expect(result.images["1:1"].mimeType).toBe("image/png");
+    expect(typeof result.images["2:2"].imageData).toBe("string");
+    expect(result.errors).toBeUndefined();
+    expect(result.truncated).toBeUndefined();
+  });
+
+  test("per-node failure is reported in errors, batch continues", async () => {
+    fakeNodes["1:1"] = makeExportableNode("1:1", 30);
+    const result = await exportNodeAsImage({ nodeIds: ["1:1", "missing"] });
+    expect(Object.keys(result.images)).toEqual(["1:1"]);
+    expect(result.errors.missing).toMatch(/Node not found/);
+  });
+
+  test("empty array fails with a stated fix", async () => {
+    await expect(exportNodeAsImage({ nodeIds: [] })).rejects.toThrow(/Fix:/);
+  });
+
+  test("over the node cap fails with a stated fix", async () => {
+    const ids = Array.from({ length: 21 }, (_, i) => `n:${i}`);
+    await expect(exportNodeAsImage({ nodeIds: ids })).rejects.toThrow(/max 20.*Fix:/s);
+  });
+
+  test("payload cap truncates remaining nodes", async () => {
+    // base64 inflates ~4/3: each ~1.5MB raw node is ~2MB of base64 chars.
+    // Cap is 4M chars, so nodes 1+2 fit (~4M) and node 3 is truncated.
+    fakeNodes["1:1"] = makeExportableNode("1:1", 1_500_000);
+    fakeNodes["2:2"] = makeExportableNode("2:2", 1_500_000);
+    fakeNodes["3:3"] = makeExportableNode("3:3", 1_500_000);
+    const result = await exportNodeAsImage({ nodeIds: ["1:1", "2:2", "3:3"] });
+    expect(Object.keys(result.images)).toEqual(["1:1", "2:2"]);
+    expect(result.truncated).toEqual(["3:3"]);
+  });
+});

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -90,4 +90,38 @@ describe("exportNodeAsImage: batch mode (nodeIds array)", () => {
     expect(Object.keys(result.images)).toEqual(["1:1", "2:2"]);
     expect(result.truncated).toEqual(["3:3"]);
   });
+
+  test("cap is a ceiling: a node that would overshoot is truncated, not appended", async () => {
+    // Node 1 ~2.67M base64 chars, node 2 ~2.67M — together ~5.3M > 4M cap.
+    // After-export check truncates node 2 instead of letting the total overshoot.
+    fakeNodes["1:1"] = makeExportableNode("1:1", 2_000_000);
+    fakeNodes["2:2"] = makeExportableNode("2:2", 2_000_000);
+    const result = await exportNodeAsImage({ nodeIds: ["1:1", "2:2"] });
+    expect(Object.keys(result.images)).toEqual(["1:1"]);
+    expect(result.truncated).toEqual(["2:2"]);
+    expect(result.images["1:1"].imageData.length).toBeLessThanOrEqual(4_000_000);
+  });
+
+  test("a single oversized first node is still returned (never empty)", async () => {
+    // 5MB raw → ~6.7M base64 chars, larger than the whole 4M cap, but it is
+    // the first image so it is returned rather than silently producing nothing.
+    fakeNodes["1:1"] = makeExportableNode("1:1", 5_000_000);
+    const result = await exportNodeAsImage({ nodeIds: ["1:1"] });
+    expect(Object.keys(result.images)).toEqual(["1:1"]);
+    expect(result.truncated).toBeUndefined();
+  });
+
+  test("a non-Error thrown value is stored as a string (no undefined)", async () => {
+    fakeNodes["1:1"] = makeExportableNode("1:1", 30);
+    fakeNodes["bad"] = {
+      id: "bad",
+      type: "FRAME",
+      name: "bad",
+      // Simulate a Figma-internal rejection with a non-Error value (no .message).
+      exportAsync: () => Promise.reject("kaboom"),
+    };
+    const result = await exportNodeAsImage({ nodeIds: ["1:1", "bad"] });
+    expect(Object.keys(result.images)).toEqual(["1:1"]);
+    expect(result.errors.bad).toBe("kaboom");
+  });
 });


### PR DESCRIPTION
## Summary

Extends the existing `export_node_as_image` wire command (no new wire command, no protocol-surface change) to accept either a single `nodeId` (unchanged, backward compatible) or a `nodeIds` array. Batch mode returns images keyed by nodeId, continues past per-node failures (reported under `errors`), and enforces two caps: **max 20 nodes/call** and a **~4MB total payload budget** (over-budget nodes listed under `truncated` for a follow-up batch). The `screenshot` tool interleaves a `nodeId: <id>` marker before each image block so batch results stay attributable.

## Files
`src/figma_plugin/src/commands/document.js` (shared `exportSingleNode` helper + dispatch), `src/figmagent_mcp/tools/export.ts` (nodeIds param + description), `tests/export.test.ts` (new, 8 tests).

## Validation
`bun run lint` clean · `bun run build:plugin` clean (code.js gitignored) · new `export.test.ts` 8/8, full suite green excluding the flaky connection tests.

> Note: the pre-existing `tests/connection.test.ts` WebSocket port-contention failures reproduce identically on clean `origin/main` and are unrelated to this change.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)